### PR TITLE
feat: Swift 6 migration + explicit Sendable conformances

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -25,5 +25,6 @@ let package = Package(
             name: "OpenLibraryTests",
             dependencies: ["OpenLibrary"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v6]
 )

--- a/Sources/OpenLibrary/OpenLibraryAPI.swift
+++ b/Sources/OpenLibrary/OpenLibraryAPI.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// An OpenLibrary API client.
 ///
-public struct OpenLibraryAPI {
+public struct OpenLibraryAPI: Sendable {
 
     let logger: OpenLibraryLoggerProtocol?
 

--- a/Sources/OpenLibrary/OpenLibraryAPIMocks.swift
+++ b/Sources/OpenLibrary/OpenLibraryAPIMocks.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 
-public enum OpenLibraryMocks {
+public enum OpenLibraryMocks: Sendable {
     public static let book = try! JSONDecoder().decode(
         OpenLibrarySearchResponse.self,
         from: OpenLibraryAPIMocks.search.data(using: .utf8)!
@@ -15,7 +15,7 @@ public enum OpenLibraryMocks {
 }
 
 /// Holds mocked API responses
-public enum OpenLibraryAPIMocks {
+public enum OpenLibraryAPIMocks: Sendable {
 
     // MARK: - Twitter and Tear Gas Editions
     //

--- a/Sources/OpenLibrary/OpenLibraryEdition.swift
+++ b/Sources/OpenLibrary/OpenLibraryEdition.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// Describes OpenLibrary API Editions response
 /// i.e. https://openlibrary.org/works/OL20057658W/editions.json
-public struct OpenLibraryEditionsResponse: Codable {
+public struct OpenLibraryEditionsResponse: Codable, Sendable {
     public let entries: [OpenLibraryEdition]
 }
 
@@ -243,13 +243,13 @@ extension OpenLibraryEdition {
 
 extension OpenLibraryEdition {
 
-    public struct LanguageDescription: Codable {
+    public struct LanguageDescription: Codable, Sendable {
         let key: String
     }
 
     /// OpenLibrary field wrapped in a type + value struct
     ///
-    public struct Description: Codable {
+    public struct Description: Codable, Sendable {
         let type: String
         let value: String
     }
@@ -273,14 +273,14 @@ extension OpenLibraryEdition {
 
     /// Describes a wrapped date time type
     ///
-    public struct OLDateTime: Codable {
+    public struct OLDateTime: Codable, Sendable {
         let type: String
         let value: Date
     }
 
     /// Describes possible book formats, agnostic of the book provider
     ///
-    public enum BookFormat: String, Codable {
+    public enum BookFormat: String, Codable, Sendable {
         case ebook
         case paper
         case audio

--- a/Sources/OpenLibrary/OpenLibraryLogger.swift
+++ b/Sources/OpenLibrary/OpenLibraryLogger.swift
@@ -14,14 +14,14 @@ import Foundation
 ///
 /// If you're building for an Apple platform, `OSLog.Logger` is the easiest option to go with, and it will work out of the box.
 ///
-public protocol OpenLibraryLoggerProtocol {
+public protocol OpenLibraryLoggerProtocol: Sendable {
     /// Basic logging functions that implementations must provide
     func debug(_ message: @autoclosure () -> String)
     func info(_ message: @autoclosure () -> String)
     func error(_ message: @autoclosure () -> String)
 }
 
-// On Apple platforms, patch extend the default Logger to work with KindleAPI
+// On Apple platforms, patch extend the default Logger to work with OpenLibrary
 //
 #if canImport(OSLog)
 
@@ -29,15 +29,18 @@ public protocol OpenLibraryLoggerProtocol {
 
     extension Logger: OpenLibraryLoggerProtocol {
         public func debug(_ message: @autoclosure () -> String) {
-            self.debug("\(message())")
+            let msg = message()
+            self.log(level: .debug, "\(msg)")
         }
 
         public func info(_ message: @autoclosure () -> String) {
-            self.info("\(message())")
+            let msg = message()
+            self.log(level: .info, "\(msg)")
         }
 
         public func error(_ message: @autoclosure () -> String) {
-            self.error("\(message())")
+            let msg = message()
+            self.log(level: .error, "\(msg)")
         }
     }
 

--- a/Sources/OpenLibrary/OpenLibraryWork.swift
+++ b/Sources/OpenLibrary/OpenLibraryWork.swift
@@ -14,7 +14,7 @@ import Foundation
 ///     - This has more fields available, i.e. num_found etc.
 ///     - Consider adding pagination to the corresponding method
 ///
-public struct OpenLibrarySearchResponse: Codable {
+public struct OpenLibrarySearchResponse: Codable, Sendable {
     public let docs: [OpenLibrarySearchResult]
 }
 


### PR DESCRIPTION
## Summary

- Updates `Package.swift` to `swift-tools-version: 6.0` with `swiftLanguageModes: [.v6]`
- Adds explicit `Sendable` conformance to all public types: `OpenLibraryAPI`, `OpenLibrarySearchResponse`, `OpenLibraryEditionsResponse`, `OpenLibraryLoggerProtocol`, `OpenLibraryMocks`, `OpenLibraryAPIMocks`, and all nested types in `OpenLibraryEdition`
- Fixes infinite recursion warnings in the `Logger` extension by using `log(level:)` instead of calling protocol methods that recursively dispatch back to themselves

## Test plan

- [x] `swift build` produces zero errors and zero warnings
- [x] `swift test` passes all 12 tests in 2 suites
- [x] All existing tests preserved (tests were already in Swift Testing format)
- [x] No tests removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)