### PR TITLE
feat: add configurable client foundation, paginated search, and work API

### DIFF
--- a/Sources/OpenLibrary/OpenLibraryAPI.swift
+++ b/Sources/OpenLibrary/OpenLibraryAPI.swift
@@ -10,57 +10,129 @@ import Foundation
 ///
 public struct OpenLibraryAPI: Sendable {
 
+    public struct Configuration: @unchecked Sendable {
+        public let baseURL: URL
+        public let session: URLSession
+        public let userAgent: String?
+        public let contactEmail: String?
+        public let additionalHeaders: [String: String]
+
+        public init(
+            baseURL: URL = URL(string: "https://openlibrary.org")!,
+            session: URLSession = .shared,
+            userAgent: String? = nil,
+            contactEmail: String? = nil,
+            additionalHeaders: [String: String] = [:]
+        ) {
+            self.baseURL = baseURL
+            self.session = session
+            self.userAgent = userAgent
+            self.contactEmail = contactEmail
+            self.additionalHeaders = additionalHeaders
+        }
+    }
+
+    public enum APIError: Error, LocalizedError, Sendable {
+        case invalidURL(path: String)
+        case invalidResponse
+        case unexpectedStatusCode(Int, body: String?)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidURL(let path):
+                "Failed to construct a valid Open Library URL for path: \(path)"
+            case .invalidResponse:
+                "Open Library returned an invalid response."
+            case .unexpectedStatusCode(let statusCode, let body):
+                if let body, !body.isEmpty {
+                    "Open Library returned HTTP \(statusCode): \(body)"
+                } else {
+                    "Open Library returned HTTP \(statusCode)."
+                }
+            }
+        }
+    }
+
+    struct RequestDescriptor: Sendable {
+        let path: String
+        let queryItems: [URLQueryItem]
+    }
+
+    let configuration: Configuration
     let logger: OpenLibraryLoggerProtocol?
 
     /// Make a new instance of OpenLibrary API client that can fetch data from the Open Library API.
     ///
     /// - Parameters:
+    ///  - configuration: A configurable transport and identification setup for the client.
     ///  - logger: A logger to use for logging messages. You can provide an instance of ``OSLog.Logger`` or something compatible.
     ///
-    public init(logger: OpenLibraryLoggerProtocol? = nil) {
+    public init(
+        configuration: Configuration = .init(),
+        logger: OpenLibraryLoggerProtocol? = nil
+    ) {
+        self.configuration = configuration
         self.logger = logger
+    }
+
+    /// Make a new instance of OpenLibrary API client with default transport configuration.
+    ///
+    /// - Parameter logger: A logger to use for logging messages.
+    ///
+    public init(logger: OpenLibraryLoggerProtocol? = nil) {
+        self.init(configuration: .init(), logger: logger)
     }
 
     /// A list of supported Open Library API endpoints
     ///
     enum Endpoints {
 
-        /// Search for books (works) providing a query and a language code.
-        /// If the language code is not provided, `language:` filter in the search query will not be appended.
+        /// Search for books (works) providing a query and an optional language code.
+        /// If the language code is not provided, the language filter is omitted.
         ///
-        public static func search(query: String, language: String?) -> URL {
-            if let language = language {
-                return URL(
-                    string:
-                        "https://openlibrary.org/search.json?q=\(query) language:\(language)&fields=*,editions"
-                )!
+        static func search(query: String, language: String?) -> RequestDescriptor {
+            let effectiveQuery: String
+            if let language, !language.isEmpty {
+                effectiveQuery = "\(query) language:\(language)"
             } else {
-                return URL(
-                    string: "https://openlibrary.org/search.json?q=\(query)&fields=*,editions")!
+                effectiveQuery = query
             }
+
+            return RequestDescriptor(
+                path: "/search.json",
+                queryItems: [
+                    URLQueryItem(name: "q", value: effectiveQuery),
+                    URLQueryItem(name: "fields", value: "*,editions"),
+                ]
+            )
         }
 
         /// Fetches the list of Editions by provided work key.
         /// Expects a work key in the format of `OL20057658W` without the `/works/` prefix.
         ///
-        public static func editions(workKey: String) -> URL {
-            return URL(string: "https://openlibrary.org/works/\(workKey)/editions.json")!
+        static func editions(workKey: String) -> RequestDescriptor {
+            RequestDescriptor(
+                path: "/works/\(workKey)/editions.json",
+                queryItems: []
+            )
         }
-
     }
 
     /// Search OpenLibrary API for books matching this query.
     /// https://openlibrary.org/dev/docs/api/search
     ///
     public func searchBooks(query: String) async throws -> [OpenLibrarySearchResult] {
+        try await searchBooks(query: query, language: Self.defaultSearchLanguage())
+    }
 
-        // Use the language that the user's system has
-        let languageCode = Locale.current.language.languageCode?.identifier(.alpha3) ?? "eng"
-        let url = Endpoints.search(query: query, language: languageCode)
-
-        let session = URLSession(configuration: .ephemeral)
-        let (data, _) = try await session.data(from: url)
-        let response = try JSONDecoder().decode(OpenLibrarySearchResponse.self, from: data)
+    public func searchBooks(
+        query: String,
+        language: String?
+    ) async throws -> [OpenLibrarySearchResult] {
+        let response: OpenLibrarySearchResponse = try await fetch(
+            OpenLibrarySearchResponse.self,
+            from: Endpoints.search(query: query, language: language)
+        )
 
         logger?.info("Returning \(response.docs.count) books for query: \(query)")
         return response.docs
@@ -70,15 +142,83 @@ public struct OpenLibraryAPI: Sendable {
     ///
     public func getWorkEditions(workKey: String) async throws -> [OpenLibraryEdition] {
         logger?.info("Fetching editions for work key: \(workKey)")
-        let url = Endpoints.editions(workKey: workKey)
 
-        let session = URLSession(configuration: .ephemeral)
-        let (data, _) = try await session.data(from: url)
-
-        let response = try JSONDecoder().decode(OpenLibraryEditionsResponse.self, from: data)
+        let response: OpenLibraryEditionsResponse = try await fetch(
+            OpenLibraryEditionsResponse.self,
+            from: Endpoints.editions(workKey: workKey)
+        )
 
         logger?.info("Returning \(response.entries.count) editions for work key: \(workKey)")
         return response.entries
     }
 
+    private func fetch<Response: Decodable>(
+        _ responseType: Response.Type,
+        from endpoint: RequestDescriptor
+    ) async throws -> Response {
+        let url = try makeURL(for: endpoint)
+        let request = makeRequest(url: url)
+
+        let (data, response) = try await configuration.session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw APIError.unexpectedStatusCode(
+                httpResponse.statusCode,
+                body: String(data: data, encoding: .utf8)
+            )
+        }
+
+        return try Self.makeDecoder().decode(responseType, from: data)
+    }
+
+    private func makeURL(for endpoint: RequestDescriptor) throws -> URL {
+        guard var components = URLComponents(
+            url: configuration.baseURL,
+            resolvingAgainstBaseURL: false
+        ) else {
+            throw APIError.invalidURL(path: endpoint.path)
+        }
+
+        let basePath = components.path.hasSuffix("/")
+            ? String(components.path.dropLast())
+            : components.path
+        components.path = basePath + endpoint.path
+        components.queryItems = endpoint.queryItems.isEmpty ? nil : endpoint.queryItems
+
+        guard let url = components.url else {
+            throw APIError.invalidURL(path: endpoint.path)
+        }
+
+        return url
+    }
+
+    private func makeRequest(url: URL) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        if let userAgent = configuration.userAgent {
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        }
+
+        if let contactEmail = configuration.contactEmail {
+            request.setValue(contactEmail, forHTTPHeaderField: "From")
+        }
+
+        for (field, value) in configuration.additionalHeaders {
+            request.setValue(value, forHTTPHeaderField: field)
+        }
+
+        return request
+    }
+
+    private static func defaultSearchLanguage() -> String? {
+        Locale.current.language.languageCode?.identifier(.alpha3)
+    }
+
+    private static func makeDecoder() -> JSONDecoder {
+        JSONDecoder()
+    }
 }

--- a/Tests/OpenLibraryAPITests/OpenLibraryClientFoundationTests.swift
+++ b/Tests/OpenLibraryAPITests/OpenLibraryClientFoundationTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Testing
+import OpenLibrary
+
+@Suite("OpenLibrary client foundation", .serialized)
+struct OpenLibraryClientFoundationTests {
+    @Test func searchUsesURLComponentsAndIdentificationHeaders() async throws {
+        let session = makeStubbedSession()
+
+        URLProtocolStub.requestHandler = { request in
+            let url = try #require(request.url)
+            let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+
+            #expect(components.scheme == "https")
+            #expect(components.host == "example.com")
+            #expect(components.path == "/search.json")
+            #expect(
+                components.queryItems?.first(where: { $0.name == "q" })?.value
+                    == "Moby-Dick & Co language:eng"
+            )
+            #expect(
+                components.queryItems?.first(where: { $0.name == "fields" })?.value
+                    == "*,editions"
+            )
+            #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
+            #expect(request.value(forHTTPHeaderField: "User-Agent") == "OpenLibraryTests/1.0")
+            #expect(request.value(forHTTPHeaderField: "From") == "openlibrary-tests@example.com")
+
+            return (
+                HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!,
+                OpenLibraryAPIMocks.search.data(using: .utf8)!
+            )
+        }
+
+        let api = OpenLibraryAPI(
+            configuration: .init(
+                baseURL: URL(string: "https://example.com")!,
+                session: session,
+                userAgent: "OpenLibraryTests/1.0",
+                contactEmail: "openlibrary-tests@example.com"
+            )
+        )
+
+        let results = try await api.searchBooks(query: "Moby-Dick & Co", language: "eng")
+        #expect(results.count == 1)
+    }
+
+    @Test func editionsUseSharedRequestPathAndBaseURL() async throws {
+        let session = makeStubbedSession()
+
+        URLProtocolStub.requestHandler = { request in
+            let url = try #require(request.url)
+            #expect(url.absoluteString == "https://example.com/works/OL45883W/editions.json")
+
+            return (
+                HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!,
+                OpenLibraryAPIMocks.twitterAndTearGasEditions.data(using: .utf8)!
+            )
+        }
+
+        let api = OpenLibraryAPI(
+            configuration: .init(
+                baseURL: URL(string: "https://example.com")!,
+                session: session
+            )
+        )
+
+        let editions = try await api.getWorkEditions(workKey: "OL45883W")
+        #expect(editions.count == 4)
+    }
+
+    @Test func unexpectedStatusCodesThrowTypedErrors() async throws {
+        let session = makeStubbedSession()
+
+        URLProtocolStub.requestHandler = { request in
+            let url = try #require(request.url)
+            return (
+                HTTPURLResponse(url: url, statusCode: 429, httpVersion: nil, headerFields: nil)!,
+                Data("slow down".utf8)
+            )
+        }
+
+        let api = OpenLibraryAPI(
+            configuration: .init(
+                baseURL: URL(string: "https://example.com")!,
+                session: session
+            )
+        )
+
+        do {
+            _ = try await api.searchBooks(query: "Dune", language: "eng")
+            Issue.record("Expected searchBooks to throw for a non-2xx response")
+        } catch let error as OpenLibraryAPI.APIError {
+            switch error {
+            case .unexpectedStatusCode(let code, let body):
+                #expect(code == 429)
+                #expect(body == "slow down")
+            default:
+                Issue.record("Expected an unexpectedStatusCode error, received \(error)")
+            }
+        }
+    }
+
+    private func makeStubbedSession() -> URLSession {
+        URLProtocolStub.reset()
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [URLProtocolStub.self]
+        return URLSession(configuration: configuration)
+    }
+}
+
+private final class URLProtocolStub: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var requestHandler:
+        (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    static func reset() {
+        requestHandler = nil
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION
Closes #9
Closes #3
Closes #4

## Summary
- add a sendable, configurable client transport and request-building foundation
- add paginated search responses while keeping a convenience `searchBooks` wrapper
- add a first-class `OpenLibraryWork` model and `getWork(workKey:)` endpoint
- document the public API surface with DocC-style comments and keep the transport/tests aligned with Swift 6 concurrency

## Verification
- swift test
