### PR TITLE
feat: add paginated search and work API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ import OpenLibrary
 // Initialize the client, optionally with a logger
 let client = OpenLibraryAPI()
 
-// Search for books in the user's system language
-// Returns an array of OpenLibraryWork objects
-let books = try await client.searchBooks(query: "Foundation Asimov")
+// Search for books in the user's system language.
+// Returns a paginated OpenLibrarySearchResults value.
+let search = try await client.search(query: "Foundation Asimov")
+let books = search.docs
+
+// Fetch a single work by work key.
+let work = try await client.getWork(workKey: "OL45804W")
 
 // Fetch all editions for a specific work
 // Returns an array of OpenLibraryEdition objects
@@ -39,7 +43,13 @@ let editions = try await client.getWorkEditions(workKey: "OL45883W")
 // With logging enabled (on Apple platforms)
 import OSLog
 let logger = Logger(subsystem: "com.yourapp", category: "openlibrary")
-let clientWithLogging = OpenLibraryAPI(logger: logger)
+let clientWithLogging = OpenLibraryAPI(
+    configuration: .init(
+        userAgent: "MyApp/1.0",
+        contactEmail: "me@example.com"
+    ),
+    logger: logger
+)
 ```
 
 ## Logging

--- a/Sources/OpenLibrary/OpenLibraryAPI.swift
+++ b/Sources/OpenLibrary/OpenLibraryAPI.swift
@@ -6,20 +6,68 @@
 
 import Foundation
 
+/// A small async transport abstraction used by ``OpenLibraryAPI``.
+///
+/// `OpenLibraryAPI` is fully `Sendable`, so its networking dependency also needs
+/// to be sendable under Swift 6's strict concurrency model. This protocol keeps
+/// that dependency narrow and testable while still allowing `URLSession` to be
+/// the default concrete implementation.
+public protocol OpenLibraryHTTPSession: Sendable {
+    /// Loads data for a request.
+    ///
+    /// - Parameter request: The request to execute.
+    /// - Returns: The response body and its corresponding URL response.
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: OpenLibraryHTTPSession {
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await data(for: request, delegate: nil)
+    }
+}
+
 /// An OpenLibrary API client.
 ///
+/// This type is `Sendable`, so you can safely move it across tasks and actor
+/// boundaries. It does not own mutable shared state. Request execution happens
+/// through an injected async transport (`OpenLibraryHTTPSession`) and each call
+/// builds its own immutable `URLRequest`.
 public struct OpenLibraryAPI: Sendable {
 
-    public struct Configuration: @unchecked Sendable {
+    /// Configuration for an ``OpenLibraryAPI`` instance.
+    ///
+    /// The configuration is immutable and `Sendable`, which means you can create
+    /// a client once and safely reuse it from concurrent tasks.
+    public struct Configuration: Sendable {
+        /// The base URL used to build endpoint URLs.
         public let baseURL: URL
-        public let session: URLSession
+
+        /// The async transport used to execute requests.
+        ///
+        /// In production this is normally `URLSession.shared`. In tests you can
+        /// inject a lightweight stub that conforms to ``OpenLibraryHTTPSession``.
+        public let session: any OpenLibraryHTTPSession
+
+        /// A `User-Agent` header identifying the calling application.
         public let userAgent: String?
+
+        /// A contact email used for the `From` header.
         public let contactEmail: String?
+
+        /// Additional headers applied to every request.
         public let additionalHeaders: [String: String]
 
+        /// Creates a new client configuration.
+        ///
+        /// - Parameters:
+        ///   - baseURL: The base Open Library host. Defaults to `https://openlibrary.org`.
+        ///   - session: The sendable async transport used to perform requests.
+        ///   - userAgent: A `User-Agent` header value for API identification.
+        ///   - contactEmail: A `From` header value for API identification.
+        ///   - additionalHeaders: Extra headers to include on all requests.
         public init(
             baseURL: URL = URL(string: "https://openlibrary.org")!,
-            session: URLSession = .shared,
+            session: any OpenLibraryHTTPSession = URLSession.shared,
             userAgent: String? = nil,
             contactEmail: String? = nil,
             additionalHeaders: [String: String] = [:]
@@ -32,9 +80,15 @@ public struct OpenLibraryAPI: Sendable {
         }
     }
 
+    /// Errors returned by ``OpenLibraryAPI``.
     public enum APIError: Error, LocalizedError, Sendable {
+        /// URL construction failed for the supplied endpoint path.
         case invalidURL(path: String)
+
+        /// The server returned a non-HTTP response.
         case invalidResponse
+
+        /// The server returned an unsuccessful HTTP status code.
         case unexpectedStatusCode(Int, body: String?)
 
         public var errorDescription: String? {
@@ -61,12 +115,11 @@ public struct OpenLibraryAPI: Sendable {
     let configuration: Configuration
     let logger: OpenLibraryLoggerProtocol?
 
-    /// Make a new instance of OpenLibrary API client that can fetch data from the Open Library API.
+    /// Creates a new Open Library client.
     ///
     /// - Parameters:
-    ///  - configuration: A configurable transport and identification setup for the client.
-    ///  - logger: A logger to use for logging messages. You can provide an instance of ``OSLog.Logger`` or something compatible.
-    ///
+    ///   - configuration: The immutable transport and header configuration.
+    ///   - logger: A logger to use for diagnostic messages.
     public init(
         configuration: Configuration = .init(),
         logger: OpenLibraryLoggerProtocol? = nil
@@ -75,21 +128,14 @@ public struct OpenLibraryAPI: Sendable {
         self.logger = logger
     }
 
-    /// Make a new instance of OpenLibrary API client with default transport configuration.
+    /// Creates a new client with the default configuration.
     ///
-    /// - Parameter logger: A logger to use for logging messages.
-    ///
+    /// - Parameter logger: A logger to use for diagnostic messages.
     public init(logger: OpenLibraryLoggerProtocol? = nil) {
         self.init(configuration: .init(), logger: logger)
     }
 
-    /// A list of supported Open Library API endpoints
-    ///
     enum Endpoints {
-
-        /// Search for books (works) providing a query and an optional language code.
-        /// If the language code is not provided, the language filter is omitted.
-        ///
         static func search(query: String, language: String?) -> RequestDescriptor {
             let effectiveQuery: String
             if let language, !language.isEmpty {
@@ -107,9 +153,13 @@ public struct OpenLibraryAPI: Sendable {
             )
         }
 
-        /// Fetches the list of Editions by provided work key.
-        /// Expects a work key in the format of `OL20057658W` without the `/works/` prefix.
-        ///
+        static func work(workKey: String) -> RequestDescriptor {
+            RequestDescriptor(
+                path: "/works/\(workKey).json",
+                queryItems: []
+            )
+        }
+
         static func editions(workKey: String) -> RequestDescriptor {
             RequestDescriptor(
                 path: "/works/\(workKey)/editions.json",
@@ -118,28 +168,78 @@ public struct OpenLibraryAPI: Sendable {
         }
     }
 
-    /// Search OpenLibrary API for books matching this query.
-    /// https://openlibrary.org/dev/docs/api/search
+    /// Searches Open Library and returns the full paginated response envelope.
     ///
-    public func searchBooks(query: String) async throws -> [OpenLibrarySearchResult] {
-        try await searchBooks(query: query, language: Self.defaultSearchLanguage())
+    /// - Parameter query: The search query.
+    /// - Returns: A paginated collection of search results.
+    public func search(query: String) async throws -> OpenLibrarySearchResults {
+        try await search(query: query, language: Self.defaultSearchLanguage())
     }
 
+    /// Searches Open Library and returns the full paginated response envelope.
+    ///
+    /// - Parameters:
+    ///   - query: The search query.
+    ///   - language: An optional ISO 639-2 language code applied as a search filter.
+    /// - Returns: A paginated collection of search results.
+    public func search(
+        query: String,
+        language: String?
+    ) async throws -> OpenLibrarySearchResults {
+        let response: OpenLibrarySearchResults = try await fetch(
+            OpenLibrarySearchResults.self,
+            from: Endpoints.search(query: query, language: language)
+        )
+
+        logger?.info("Returning \(response.docs.count) search results for query: \(query)")
+        return response
+    }
+
+    /// Searches Open Library and returns only the search documents.
+    ///
+    /// This remains as a convenience wrapper around ``search(query:language:)``.
+    ///
+    /// - Parameter query: The search query.
+    /// - Returns: The `docs` array from the paginated search response.
+    public func searchBooks(query: String) async throws -> [OpenLibrarySearchResult] {
+        let response = try await search(query: query)
+        return response.docs
+    }
+
+    /// Searches Open Library and returns only the search documents.
+    ///
+    /// - Parameters:
+    ///   - query: The search query.
+    ///   - language: An optional ISO 639-2 language code applied as a search filter.
+    /// - Returns: The `docs` array from the paginated search response.
     public func searchBooks(
         query: String,
         language: String?
     ) async throws -> [OpenLibrarySearchResult] {
-        let response: OpenLibrarySearchResponse = try await fetch(
-            OpenLibrarySearchResponse.self,
-            from: Endpoints.search(query: query, language: language)
-        )
-
-        logger?.info("Returning \(response.docs.count) books for query: \(query)")
+        let response = try await search(query: query, language: language)
         return response.docs
     }
 
-    /// Fetches all editions for a particular work key, without pagination
+    /// Fetches an individual work.
     ///
+    /// - Parameter workKey: A work key such as `OL45804W`, without the `/works/` prefix.
+    /// - Returns: The decoded work record.
+    public func getWork(workKey: String) async throws -> OpenLibraryWork {
+        logger?.info("Fetching work for key: \(workKey)")
+
+        let response: OpenLibraryWork = try await fetch(
+            OpenLibraryWork.self,
+            from: Endpoints.work(workKey: workKey)
+        )
+
+        logger?.info("Returning work for key: \(workKey)")
+        return response
+    }
+
+    /// Fetches all editions for a work, without automatically traversing pagination.
+    ///
+    /// - Parameter workKey: A work key such as `OL45804W`, without the `/works/` prefix.
+    /// - Returns: The first page of editions for the work.
     public func getWorkEditions(workKey: String) async throws -> [OpenLibraryEdition] {
         logger?.info("Fetching editions for work key: \(workKey)")
 
@@ -152,6 +252,11 @@ public struct OpenLibraryAPI: Sendable {
         return response.entries
     }
 
+    /// Performs a request and decodes the JSON payload.
+    ///
+    /// The async boundary here is the network call. All request-building data is
+    /// immutable before the `await`, so no synchronization is needed inside the
+    /// client itself.
     private func fetch<Response: Decodable>(
         _ responseType: Response.Type,
         from endpoint: RequestDescriptor

--- a/Sources/OpenLibrary/OpenLibrarySearch.swift
+++ b/Sources/OpenLibrary/OpenLibrarySearch.swift
@@ -1,0 +1,164 @@
+//
+//  OpenLibrarySearch.swift
+//
+//  Created by Natik Gadzhi on 12/23/24.
+//
+
+import Foundation
+
+/// A paginated Open Library search response.
+///
+/// Open Library search results contain both pagination metadata and an array of
+/// work-shaped documents. This envelope is the preferred return type for search
+/// APIs because it preserves `start` and `numFound` for callers that need to
+/// page or present total-result counts.
+public struct OpenLibrarySearchResults: Decodable, Sendable {
+    /// The zero-based offset for this page.
+    public let start: Int
+
+    /// The total number of matching records.
+    public let numFound: Int
+
+    /// Whether the total record count is exact.
+    public let numFoundExact: Bool?
+
+    /// The search documents for this page.
+    public let docs: [OpenLibrarySearchResult]
+
+    /// A convenience alias for ``docs``.
+    public var results: [OpenLibrarySearchResult] { docs }
+
+    enum CodingKeys: String, CodingKey {
+        case start
+        case numFound
+        case numFoundSnakeCase = "num_found"
+        case numFoundExact
+        case numFoundExactSnakeCase = "num_found_exact"
+        case docs
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        start = try container.decodeIfPresent(Int.self, forKey: .start) ?? 0
+        numFound = try container.decodeIfPresent(Int.self, forKey: .numFound)
+            ?? container.decode(Int.self, forKey: .numFoundSnakeCase)
+        numFoundExact = try container.decodeIfPresent(Bool.self, forKey: .numFoundExact)
+            ?? container.decodeIfPresent(Bool.self, forKey: .numFoundExactSnakeCase)
+        docs = try container.decode([OpenLibrarySearchResult].self, forKey: .docs)
+    }
+}
+
+/// A backwards-compatible alias for the pre-pagination response name.
+public typealias OpenLibrarySearchResponse = OpenLibrarySearchResults
+
+/// A work-shaped search document returned by `/search.json`.
+public struct OpenLibrarySearchResult: Decodable, Identifiable, Hashable, Sendable {
+
+    enum CodingKeys: String, CodingKey {
+        case key
+        case title
+        case subtitle
+        case authorNames = "author_name"
+        case authorKeys = "author_key"
+        case coverImageID = "cover_i"
+        case editionCount = "edition_count"
+        case firstPublishYear = "first_publish_year"
+        case editionISBNs = "isbn"
+        case editionKeys = "edition_key"
+        case language
+        case hasFullText = "has_fulltext"
+        case publicScan = "public_scan_b"
+        case asin = "id_amazon"
+        case wikidataID = "id_wikidata"
+        case subjects = "subject"
+    }
+
+    /// The normalized work identifier without the `/works/` prefix.
+    public var id: String { key }
+
+    /// The normalized work key.
+    public let key: String
+
+    /// The work title.
+    public let title: String
+
+    /// The work subtitle if present.
+    public let subtitle: String?
+
+    /// The author names returned on the search document.
+    public let authorNames: [String]?
+
+    /// The normalized author keys returned on the search document.
+    public let authorKeys: [String]?
+
+    /// The Open Library cover identifier.
+    public let coverImageID: Int?
+
+    /// The number of editions attached to the work.
+    public let editionCount: Int?
+
+    /// The earliest publication year returned by search.
+    public let firstPublishYear: Int?
+
+    /// ISBN values surfaced through search.
+    public let editionISBNs: [String]?
+
+    /// Edition keys surfaced through search.
+    public let editionKeys: [String]?
+
+    /// Language codes attached to the search document.
+    public let language: [String]?
+
+    /// Whether full text is available.
+    public let hasFullText: Bool?
+
+    /// Whether a public scan exists.
+    public let publicScan: Bool?
+
+    /// Amazon identifiers surfaced through search.
+    public let asin: [String]?
+
+    /// Wikidata identifiers surfaced through search.
+    public let wikidataID: [String]?
+
+    /// Subject tags surfaced through search.
+    public let subjects: [String]?
+
+    /// The large cover image URL if a cover identifier is present.
+    public var coverImageURL: URL? {
+        guard let coverImageID else { return nil }
+        return URL(string: "https://covers.openlibrary.org/b/id/\(coverImageID)-L.jpg")
+    }
+
+    /// The first author name if one is present.
+    public var author: String? {
+        authorNames?.first
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let prefixedWorkKey = try container.decode(String.self, forKey: .key)
+        if prefixedWorkKey.starts(with: "/works/") {
+            key = String(prefixedWorkKey.dropFirst(7))
+        } else {
+            key = prefixedWorkKey
+        }
+
+        title = try container.decode(String.self, forKey: .title)
+        subtitle = try container.decodeIfPresent(String.self, forKey: .subtitle)
+        authorNames = try container.decodeIfPresent([String].self, forKey: .authorNames)
+        authorKeys = try container.decodeIfPresent([String].self, forKey: .authorKeys)
+        coverImageID = try container.decodeIfPresent(Int.self, forKey: .coverImageID)
+        editionCount = try container.decodeIfPresent(Int.self, forKey: .editionCount)
+        firstPublishYear = try container.decodeIfPresent(Int.self, forKey: .firstPublishYear)
+        editionISBNs = try container.decodeIfPresent([String].self, forKey: .editionISBNs)
+        editionKeys = try container.decodeIfPresent([String].self, forKey: .editionKeys)
+        language = try container.decodeIfPresent([String].self, forKey: .language)
+        hasFullText = try container.decodeIfPresent(Bool.self, forKey: .hasFullText)
+        publicScan = try container.decodeIfPresent(Bool.self, forKey: .publicScan)
+        asin = try container.decodeIfPresent([String].self, forKey: .asin)
+        wikidataID = try container.decodeIfPresent([String].self, forKey: .wikidataID)
+        subjects = try container.decodeIfPresent([String].self, forKey: .subjects)
+    }
+}

--- a/Sources/OpenLibrary/OpenLibraryWork.swift
+++ b/Sources/OpenLibrary/OpenLibraryWork.swift
@@ -6,98 +6,179 @@
 
 import Foundation
 
-
-/// Describes OpenLibrary API Search response.
-/// I.e. https://openlibrary.org/search.json?q=
-///
-/// TODO:
-///     - This has more fields available, i.e. num_found etc.
-///     - Consider adding pagination to the corresponding method
-///
-public struct OpenLibrarySearchResponse: Codable, Sendable {
-    public let docs: [OpenLibrarySearchResult]
-}
-
-
-/// Describes an OpenLibrary Book as a "Work" in search results.
-/// Depending on the search query, this may include editions or several fields.
-/// 
-public struct OpenLibrarySearchResult: Codable, Identifiable, Hashable, Sendable {
-
+/// A complete Open Library work record fetched from `/works/{id}.json`.
+public struct OpenLibraryWork: Codable, Identifiable, Hashable, Sendable {
     enum CodingKeys: String, CodingKey {
         case key
         case title
-        case authorNames = "author_name"
-        case coverImageID = "cover_i"
-        case editionISBNs = "isbn"
-        case editionKeys = "edition_key"
-        case asin = "id_amazon"
-        case wikidataID = "id_wikidata"
-        case subjects = "subject"
+        case subtitle
+        case description
+        case authors
+        case covers
+        case subjects
+        case subjectPlaces = "subject_places"
+        case subjectPeople = "subject_people"
+        case subjectTimes = "subject_times"
+        case firstPublishDate = "first_publish_date"
+        case latestRevision = "latest_revision"
+        case revision
+        case created
+        case lastModified = "last_modified"
     }
 
-    /// Work ID is it's `key` field.
-    ///
+    /// The normalized work identifier without the `/works/` prefix.
     public var id: String { key }
 
-    /// An OpenLibrary work key, usually `OL20057658W` or similar, without the `/works/` prefix.
+    /// The normalized work key, for example `OL45804W`.
     public let key: String
 
-    /// Book title
+    /// The work title.
     public let title: String
 
-    /// Author name(s)
-    public let authorNames: [String]?
+    /// An optional subtitle for the work.
+    public let subtitle: String?
 
-    /// OpenLibrary cover integer index
-    public let coverImageID: Int?
+    /// A plain-text description when one is present.
+    public let description: String?
 
-    /// An array of ISBNs of different editions of this book
-    public let editionISBNs: [String]?
+    /// Author references attached to the work.
+    public let authors: [AuthorRole]
 
-    /// An array of OpenLibrary edition keys, without `/work` prefix
-    public let editionKeys: [String]?
+    /// Cover image identifiers associated with the work.
+    public let covers: [Int]?
 
-    /// An array of ASINs
-    public let asin: [String]?
-
-    /// An array of Wikidata work IDs
-    public let wikidataID: [String]?
-
-    /// An array of subjects for this book from OpenLibrary
+    /// Topical subjects attached to the work.
     public let subjects: [String]?
 
-    /// Returns a URL for the cover image that is ready to present
+    /// Geographic subject tags attached to the work.
+    public let subjectPlaces: [String]?
+
+    /// Person-based subject tags attached to the work.
+    public let subjectPeople: [String]?
+
+    /// Time-based subject tags attached to the work.
+    public let subjectTimes: [String]?
+
+    /// The first publish date string as returned by Open Library.
+    public let firstPublishDate: String?
+
+    /// The latest revision number on the work.
+    public let latestRevision: Int?
+
+    /// The current revision number on the work.
+    public let revision: Int?
+
+    /// The creation timestamp wrapper returned by Open Library.
+    public let created: RecordTimestamp?
+
+    /// The last-modified timestamp wrapper returned by Open Library.
+    public let lastModified: RecordTimestamp?
+
+    /// Cover image URLs derived from ``covers``.
+    public var coverImageURLs: [URL] {
+        (covers ?? []).compactMap { URL(string: "https://covers.openlibrary.org/b/id/\($0)-L.jpg") }
+    }
+
+    /// The first cover image URL if one exists.
     public var coverImageURL: URL? {
-        guard let coverImageID = coverImageID else { return nil }
-        return URL(string: "https://covers.openlibrary.org/b/id/\(coverImageID)-L.jpg")
+        coverImageURLs.first
     }
 
-    /// Single author string
-    public var author: String? {
-        authorNames?.first
+    /// The normalized author keys associated with this work.
+    public var authorKeys: [String] {
+        authors.map(\.author.key)
     }
 
+    /// Creates a work from a decoder.
+    ///
+    /// Open Library returns several fields in multiple shapes, especially
+    /// `description`, which may be a wrapped text object or a plain string.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        // Remove the work key `/works/` prefix if it exists
-        let prefixedWorkKey = try container.decode(String.self, forKey: .key)
-        if prefixedWorkKey.starts(with: "/works/") {
-            key = String(prefixedWorkKey.dropFirst(7)) }
-        else {
-            key = prefixedWorkKey
-        }
-
+        key = Self.normalizeWorkKey(try container.decode(String.self, forKey: .key))
         title = try container.decode(String.self, forKey: .title)
-        authorNames = try container.decodeIfPresent([String].self, forKey: .authorNames)
-        coverImageID = try container.decodeIfPresent(Int.self, forKey: .coverImageID)
-        editionISBNs = try container.decodeIfPresent([String].self, forKey: .editionISBNs)
-        editionKeys = try container.decodeIfPresent([String].self, forKey: .editionKeys)
-        asin = try container.decodeIfPresent([String].self, forKey: .asin)
-        wikidataID = try container.decodeIfPresent([String].self, forKey: .wikidataID)
+        subtitle = try container.decodeIfPresent(String.self, forKey: .subtitle)
+        authors = try container.decodeIfPresent([AuthorRole].self, forKey: .authors) ?? []
+        covers = try container.decodeIfPresent([Int].self, forKey: .covers)
         subjects = try container.decodeIfPresent([String].self, forKey: .subjects)
+        subjectPlaces = try container.decodeIfPresent([String].self, forKey: .subjectPlaces)
+        subjectPeople = try container.decodeIfPresent([String].self, forKey: .subjectPeople)
+        subjectTimes = try container.decodeIfPresent([String].self, forKey: .subjectTimes)
+        firstPublishDate = try container.decodeIfPresent(String.self, forKey: .firstPublishDate)
+        latestRevision = try container.decodeIfPresent(Int.self, forKey: .latestRevision)
+        revision = try container.decodeIfPresent(Int.self, forKey: .revision)
+        created = try container.decodeIfPresent(RecordTimestamp.self, forKey: .created)
+        lastModified = try container.decodeIfPresent(RecordTimestamp.self, forKey: .lastModified)
+
+        if let wrappedDescription = try? container.decodeIfPresent(TextValue.self, forKey: .description) {
+            description = wrappedDescription.value
+        } else {
+            description = try container.decodeIfPresent(String.self, forKey: .description)
+        }
     }
 
+    static func normalizeWorkKey(_ key: String) -> String {
+        if key.starts(with: "/works/") {
+            String(key.dropFirst(7))
+        } else {
+            key
+        }
+    }
 }
 
+extension OpenLibraryWork {
+    /// A wrapped text field used by Open Library for some string values.
+    public struct TextValue: Codable, Hashable, Sendable {
+        /// The record type key.
+        public let type: String
+
+        /// The plain string value.
+        public let value: String
+    }
+
+    /// A timestamp wrapper used by Open Library for record metadata.
+    public struct RecordTimestamp: Codable, Hashable, Sendable {
+        /// The record type key.
+        public let type: String
+
+        /// The raw timestamp string returned by the API.
+        public let value: String
+    }
+
+    /// A typed work author role.
+    public struct AuthorRole: Codable, Hashable, Sendable {
+        /// The linked author reference.
+        public let author: Reference
+
+        /// The role type wrapper returned by Open Library.
+        public let type: Reference?
+    }
+
+    /// A simple key reference wrapper.
+    public struct Reference: Codable, Hashable, Sendable {
+        /// The normalized key value without its `/authors/` or `/type/` prefix.
+        public let key: String
+
+        /// Creates a normalized reference from a decoder.
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let rawKey = try container.decode(String.self, forKey: .key)
+            key = Self.normalize(rawKey)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case key
+        }
+
+        static func normalize(_ rawKey: String) -> String {
+            if rawKey.starts(with: "/authors/") {
+                String(rawKey.dropFirst(9))
+            } else if rawKey.starts(with: "/type/") {
+                String(rawKey.dropFirst(6))
+            } else {
+                rawKey
+            }
+        }
+    }
+}

--- a/Tests/OpenLibraryAPITests/OpenLibraryClientFoundationTests.swift
+++ b/Tests/OpenLibraryAPITests/OpenLibraryClientFoundationTests.swift
@@ -1,13 +1,11 @@
 import Foundation
 import Testing
-import OpenLibrary
+@testable import OpenLibrary
 
-@Suite("OpenLibrary client foundation", .serialized)
+@Suite("OpenLibrary client foundation")
 struct OpenLibraryClientFoundationTests {
     @Test func searchUsesURLComponentsAndIdentificationHeaders() async throws {
-        let session = makeStubbedSession()
-
-        URLProtocolStub.requestHandler = { request in
+        let session = SessionStub { request in
             let url = try #require(request.url)
             let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
 
@@ -27,8 +25,8 @@ struct OpenLibraryClientFoundationTests {
             #expect(request.value(forHTTPHeaderField: "From") == "openlibrary-tests@example.com")
 
             return (
-                HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!,
-                OpenLibraryAPIMocks.search.data(using: .utf8)!
+                OpenLibraryAPIMocks.search.data(using: .utf8)!,
+                HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
             )
         }
 
@@ -41,20 +39,66 @@ struct OpenLibraryClientFoundationTests {
             )
         )
 
-        let results = try await api.searchBooks(query: "Moby-Dick & Co", language: "eng")
-        #expect(results.count == 1)
+        let results = try await api.search(query: "Moby-Dick & Co", language: "eng")
+        #expect(results.docs.count == 1)
+        #expect(results.numFound == 1)
+    }
+
+    @Test func workUsesSharedRequestPathAndBaseURL() async throws {
+        let workJSON = """
+        {
+          "title": "Fantastic Mr Fox",
+          "key": "/works/OL45804W",
+          "authors": [
+            {
+              "author": { "key": "/authors/OL34184A" },
+              "type": { "key": "/type/author_role" }
+            }
+          ],
+          "description": {
+            "type": "/type/text",
+            "value": "A clever fox outwits three farmers."
+          },
+          "covers": [6498519],
+          "subjects": ["Animals"],
+          "created": {
+            "type": "/type/datetime",
+            "value": "2009-10-15T11:34:21.437031"
+          }
+        }
+        """
+
+        let session = SessionStub { request in
+            let url = try #require(request.url)
+            #expect(url.absoluteString == "https://example.com/works/OL45804W.json")
+
+            return (
+                Data(workJSON.utf8),
+                HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            )
+        }
+
+        let api = OpenLibraryAPI(
+            configuration: .init(
+                baseURL: URL(string: "https://example.com")!,
+                session: session
+            )
+        )
+
+        let work = try await api.getWork(workKey: "OL45804W")
+        #expect(work.key == "OL45804W")
+        #expect(work.authorKeys == ["OL34184A"])
+        #expect(work.description == "A clever fox outwits three farmers.")
     }
 
     @Test func editionsUseSharedRequestPathAndBaseURL() async throws {
-        let session = makeStubbedSession()
-
-        URLProtocolStub.requestHandler = { request in
+        let session = SessionStub { request in
             let url = try #require(request.url)
             #expect(url.absoluteString == "https://example.com/works/OL45883W/editions.json")
 
             return (
-                HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!,
-                OpenLibraryAPIMocks.twitterAndTearGasEditions.data(using: .utf8)!
+                OpenLibraryAPIMocks.twitterAndTearGasEditions.data(using: .utf8)!,
+                HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
             )
         }
 
@@ -70,13 +114,11 @@ struct OpenLibraryClientFoundationTests {
     }
 
     @Test func unexpectedStatusCodesThrowTypedErrors() async throws {
-        let session = makeStubbedSession()
-
-        URLProtocolStub.requestHandler = { request in
+        let session = SessionStub { request in
             let url = try #require(request.url)
             return (
-                HTTPURLResponse(url: url, statusCode: 429, httpVersion: nil, headerFields: nil)!,
-                Data("slow down".utf8)
+                Data("slow down".utf8),
+                HTTPURLResponse(url: url, statusCode: 429, httpVersion: nil, headerFields: nil)!
             )
         }
 
@@ -88,8 +130,8 @@ struct OpenLibraryClientFoundationTests {
         )
 
         do {
-            _ = try await api.searchBooks(query: "Dune", language: "eng")
-            Issue.record("Expected searchBooks to throw for a non-2xx response")
+            _ = try await api.search(query: "Dune", language: "eng")
+            Issue.record("Expected search to throw for a non-2xx response")
         } catch let error as OpenLibraryAPI.APIError {
             switch error {
             case .unexpectedStatusCode(let code, let body):
@@ -100,47 +142,17 @@ struct OpenLibraryClientFoundationTests {
             }
         }
     }
-
-    private func makeStubbedSession() -> URLSession {
-        URLProtocolStub.reset()
-
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [URLProtocolStub.self]
-        return URLSession(configuration: configuration)
-    }
 }
 
-private final class URLProtocolStub: URLProtocol, @unchecked Sendable {
-    nonisolated(unsafe) static var requestHandler:
-        (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+/// A sendable async transport stub used to verify request construction.
+///
+/// This mirrors the production concurrency model: the client awaits a sendable
+/// dependency that performs a request and returns immutable `(Data, URLResponse)`
+/// values. No global mutable state or unsafe concurrency escapes are required.
+private struct SessionStub: OpenLibraryHTTPSession {
+    let handler: @Sendable (URLRequest) async throws -> (Data, URLResponse)
 
-    static func reset() {
-        requestHandler = nil
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await handler(request)
     }
-
-    override class func canInit(with request: URLRequest) -> Bool {
-        true
-    }
-
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-        request
-    }
-
-    override func startLoading() {
-        guard let handler = Self.requestHandler else {
-            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-            return
-        }
-
-        do {
-            let (response, data) = try handler(request)
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            client?.urlProtocol(self, didLoad: data)
-            client?.urlProtocolDidFinishLoading(self)
-        } catch {
-            client?.urlProtocol(self, didFailWithError: error)
-        }
-    }
-
-    override func stopLoading() {}
 }

--- a/Tests/OpenLibraryAPITests/OpenLibrarySearchTests.swift
+++ b/Tests/OpenLibraryAPITests/OpenLibrarySearchTests.swift
@@ -8,12 +8,20 @@ import OpenLibrary
 
 struct OpenLibrarySearchTests {
     @Test func testSearchAPIResponse() async throws {
-        let response = try JSONDecoder().decode(OpenLibrarySearchResponse.self, from: OpenLibraryAPIMocks.search.data(using: .utf8)!)
+        let response = try JSONDecoder().decode(
+            OpenLibrarySearchResults.self,
+            from: OpenLibraryAPIMocks.search.data(using: .utf8)!
+        )
+        #expect(response.numFound == 1)
+        #expect(response.start == 0)
         #expect(response.docs.count == 1)
     }
 
     @Test func testSearchReturnsBookWithCorrectImageAndAuthor() async throws {
-        let response = try JSONDecoder().decode(OpenLibrarySearchResponse.self, from: OpenLibraryAPIMocks.search.data(using: .utf8)!)
+        let response = try JSONDecoder().decode(
+            OpenLibrarySearchResults.self,
+            from: OpenLibraryAPIMocks.search.data(using: .utf8)!
+        )
         let work = response.docs.first!
         #expect( work.coverImageURL != nil )
         #expect( work.coverImageURL!.absoluteString == "https://covers.openlibrary.org/b/id/\(work.coverImageID!)-L.jpg")
@@ -21,9 +29,10 @@ struct OpenLibrarySearchTests {
 
     @Test func testOpenLibraryAPISearchEndpoint() async throws {
         let api = OpenLibraryAPI()
-        let books = try await api.searchBooks(query: "Pattern Recognition")
-        #expect(books.count != 0)
+        let response = try await api.search(query: "Pattern Recognition")
+        #expect(response.numFound > 0)
+        #expect(response.docs.count != 0)
 
-        print(books.first!.key)
+        print(response.docs.first!.key)
     }
 } 

--- a/Tests/OpenLibraryAPITests/OpenLibraryWorkTests.swift
+++ b/Tests/OpenLibraryAPITests/OpenLibraryWorkTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+import OpenLibrary
+
+struct OpenLibraryWorkTests {
+    @Test func testWorkDecodingSupportsWrappedDescriptionAndAuthorKeys() async throws {
+        let json = """
+        {
+          "title": "Fantastic Mr Fox",
+          "key": "/works/OL45804W",
+          "authors": [
+            {
+              "author": { "key": "/authors/OL34184A" },
+              "type": { "key": "/type/author_role" }
+            }
+          ],
+          "description": {
+            "type": "/type/text",
+            "value": "A clever fox outwits three farmers."
+          },
+          "covers": [6498519],
+          "subjects": ["Animals"],
+          "created": {
+            "type": "/type/datetime",
+            "value": "2009-10-15T11:34:21.437031"
+          }
+        }
+        """
+
+        let work = try JSONDecoder().decode(OpenLibraryWork.self, from: Data(json.utf8))
+        #expect(work.key == "OL45804W")
+        #expect(work.description == "A clever fox outwits three farmers.")
+        #expect(work.authorKeys == ["OL34184A"])
+        #expect(work.coverImageURL?.absoluteString == "https://covers.openlibrary.org/b/id/6498519-L.jpg")
+    }
+
+    @Test func testOpenLibraryAPIWorkEndpoint() async throws {
+        let api = OpenLibraryAPI()
+        let work = try await api.getWork(workKey: "OL45804W")
+
+        #expect(work.key == "OL45804W")
+        #expect(!work.title.isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #3
Closes #4

## Summary
- add a paginated search response envelope with first-class metadata
- add a first-class OpenLibraryWork model and getWork(workKey:) endpoint
- add DocC-style API docs and strict Swift 6 concurrency-safe transport tests

## Verification
- swift test