### PR TITLE
feat: add work ratings and bookshelves endpoints

### DIFF
--- a/Sources/OpenLibrary/OpenLibraryAPI.swift
+++ b/Sources/OpenLibrary/OpenLibraryAPI.swift
@@ -166,6 +166,20 @@ public struct OpenLibraryAPI: Sendable {
                 queryItems: []
             )
         }
+
+        static func ratings(workKey: String) -> RequestDescriptor {
+            RequestDescriptor(
+                path: "/works/\(workKey)/ratings.json",
+                queryItems: []
+            )
+        }
+
+        static func bookshelves(workKey: String) -> RequestDescriptor {
+            RequestDescriptor(
+                path: "/works/\(workKey)/bookshelves.json",
+                queryItems: []
+            )
+        }
     }
 
     /// Searches Open Library and returns the full paginated response envelope.
@@ -250,6 +264,46 @@ public struct OpenLibraryAPI: Sendable {
 
         logger?.info("Returning \(response.entries.count) editions for work key: \(workKey)")
         return response.entries
+    }
+
+    /// Fetches the rating summary and star histogram for a work.
+    ///
+    /// The returned model mirrors the `/works/{id}/ratings.json` payload and
+    /// keeps the response fully typed for downstream code.
+    ///
+    /// - Parameter workKey: A work key such as `OL18020194W`, without the `/works/` prefix.
+    /// - Returns: The decoded ratings summary for the work.
+    public func getWorkRatings(workKey: String) async throws -> OpenLibraryWorkRatingsResponse {
+        logger?.info("Fetching ratings for work key: \(workKey)")
+
+        let response: OpenLibraryWorkRatingsResponse = try await fetch(
+            OpenLibraryWorkRatingsResponse.self,
+            from: Endpoints.ratings(workKey: workKey)
+        )
+
+        logger?.info("Returning ratings for work key: \(workKey)")
+        return response
+    }
+
+    /// Fetches the public bookshelf counts for a work.
+    ///
+    /// The returned model mirrors the `/works/{id}/bookshelves.json` payload and
+    /// provides typed access to the three bookshelf counters that Open Library exposes.
+    ///
+    /// - Parameter workKey: A work key such as `OL18020194W`, without the `/works/` prefix.
+    /// - Returns: The decoded bookshelf summary for the work.
+    public func getWorkBookshelves(
+        workKey: String
+    ) async throws -> OpenLibraryWorkBookshelvesResponse {
+        logger?.info("Fetching bookshelves for work key: \(workKey)")
+
+        let response: OpenLibraryWorkBookshelvesResponse = try await fetch(
+            OpenLibraryWorkBookshelvesResponse.self,
+            from: Endpoints.bookshelves(workKey: workKey)
+        )
+
+        logger?.info("Returning bookshelves for work key: \(workKey)")
+        return response
     }
 
     /// Performs a request and decodes the JSON payload.

--- a/Sources/OpenLibrary/OpenLibraryWorkBookshelves.swift
+++ b/Sources/OpenLibrary/OpenLibraryWorkBookshelves.swift
@@ -1,0 +1,51 @@
+//
+//  OpenLibraryWorkBookshelves.swift
+//
+//  Created by Natik Gadzhi on 4/4/26.
+//
+
+import Foundation
+
+/// A typed representation of `/works/{id}/bookshelves.json`.
+///
+/// Open Library currently returns a small count object describing how many users
+/// have placed a work on each public bookshelf.
+public struct OpenLibraryWorkBookshelvesResponse: Decodable, Sendable {
+    /// The public bookshelf counts.
+    public let counts: Counts
+
+    /// The total number of shelf placements represented by this response.
+    public var totalCount: Int {
+        counts.wantToRead + counts.currentlyReading + counts.alreadyRead
+    }
+
+    /// Creates a bookshelf response from JSON returned by Open Library.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        counts = try container.decode(Counts.self, forKey: .counts)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case counts
+    }
+}
+
+extension OpenLibraryWorkBookshelvesResponse {
+    /// The count of public shelf placements by shelf type.
+    public struct Counts: Decodable, Sendable {
+        /// The count of `want-to-read` placements.
+        public let wantToRead: Int
+
+        /// The count of `currently-reading` placements.
+        public let currentlyReading: Int
+
+        /// The count of `already-read` placements.
+        public let alreadyRead: Int
+
+        private enum CodingKeys: String, CodingKey {
+            case wantToRead = "want_to_read"
+            case currentlyReading = "currently_reading"
+            case alreadyRead = "already_read"
+        }
+    }
+}

--- a/Sources/OpenLibrary/OpenLibraryWorkRatings.swift
+++ b/Sources/OpenLibrary/OpenLibraryWorkRatings.swift
@@ -1,0 +1,104 @@
+//
+//  OpenLibraryWorkRatings.swift
+//
+//  Created by Natik Gadzhi on 4/4/26.
+//
+
+import Foundation
+
+/// A typed representation of `/works/{id}/ratings.json`.
+///
+/// Open Library exposes both a summary block and a star histogram for each work.
+/// This model keeps both parts available to callers without forcing them to parse
+/// dynamic dictionaries.
+public struct OpenLibraryWorkRatingsResponse: Decodable, Sendable {
+    /// The aggregate rating summary.
+    public let summary: Summary
+
+    /// The number of ratings at each star level.
+    public let counts: RatingHistogram
+
+    /// The average star rating.
+    public var averageRating: Double {
+        summary.average
+    }
+
+    /// The number of ratings represented in the summary.
+    public var ratingCount: Int {
+        summary.count
+    }
+
+    /// Creates a ratings response from JSON returned by Open Library.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        summary = try container.decode(Summary.self, forKey: .summary)
+        counts = try container.decode(RatingHistogram.self, forKey: .counts)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case summary
+        case counts
+    }
+}
+
+extension OpenLibraryWorkRatingsResponse {
+    /// The aggregate summary returned alongside the histogram.
+    public struct Summary: Decodable, Sendable {
+        /// The arithmetic mean of all ratings.
+        public let average: Double
+
+        /// The number of ratings included in the summary.
+        public let count: Int
+
+        /// A sortable representation of the average.
+        public let sortable: Double
+    }
+
+    /// A typed five-star histogram.
+    public struct RatingHistogram: Decodable, Sendable {
+        /// The count for one-star ratings.
+        public let one: Int
+
+        /// The count for two-star ratings.
+        public let two: Int
+
+        /// The count for three-star ratings.
+        public let three: Int
+
+        /// The count for four-star ratings.
+        public let four: Int
+
+        /// The count for five-star ratings.
+        public let five: Int
+
+        /// Creates a histogram from the numeric-string keyed JSON object returned by Open Library.
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            one = try container.decode(Int.self, forKey: .one)
+            two = try container.decode(Int.self, forKey: .two)
+            three = try container.decode(Int.self, forKey: .three)
+            four = try container.decode(Int.self, forKey: .four)
+            five = try container.decode(Int.self, forKey: .five)
+        }
+
+        /// Returns the count for a specific star value.
+        public subscript(stars stars: Int) -> Int? {
+            switch stars {
+            case 1: one
+            case 2: two
+            case 3: three
+            case 4: four
+            case 5: five
+            default: nil
+            }
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case one = "1"
+            case two = "2"
+            case three = "3"
+            case four = "4"
+            case five = "5"
+        }
+    }
+}

--- a/Tests/OpenLibraryAPITests/OpenLibraryWorkExtrasTests.swift
+++ b/Tests/OpenLibraryAPITests/OpenLibraryWorkExtrasTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+import OpenLibrary
+
+@Suite("OpenLibrary work ratings and bookshelves")
+struct OpenLibraryWorkExtrasTests {
+    @Test func testRatingsDecoding() async throws {
+        let json = """
+        {"summary":{"average":4.203438395415473,"count":1047,"sortable":4.129946372357495},"counts":{"1":112,"2":35,"3":64,"4":153,"5":683}}
+        """
+
+        let response = try JSONDecoder().decode(
+            OpenLibraryWorkRatingsResponse.self,
+            from: Data(json.utf8)
+        )
+
+        #expect(response.ratingCount == 1047)
+        #expect(response.averageRating == 4.203438395415473)
+        #expect(response.counts[stars: 5] == 683)
+    }
+
+    @Test func testBookshelvesDecoding() async throws {
+        let json = """
+        {"counts":{"want_to_read":40102,"currently_reading":2586,"already_read":1330}}
+        """
+
+        let response = try JSONDecoder().decode(
+            OpenLibraryWorkBookshelvesResponse.self,
+            from: Data(json.utf8)
+        )
+
+        #expect(response.counts.wantToRead == 40102)
+        #expect(response.counts.currentlyReading == 2586)
+        #expect(response.counts.alreadyRead == 1330)
+        #expect(response.totalCount == 44018)
+    }
+
+    @Test func testOpenLibraryAPIWorkRatingsEndpoint() async throws {
+        let api = OpenLibraryAPI()
+        let response = try await api.getWorkRatings(workKey: "OL18020194W")
+
+        #expect(response.ratingCount > 0)
+        #expect(response.counts[stars: 5] ?? 0 > 0)
+    }
+
+    @Test func testOpenLibraryAPIWorkBookshelvesEndpoint() async throws {
+        let api = OpenLibraryAPI()
+        let response = try await api.getWorkBookshelves(workKey: "OL18020194W")
+
+        #expect(response.totalCount > 0)
+        #expect(response.counts.wantToRead > 0)
+    }
+}


### PR DESCRIPTION
Closes #11

## Summary
- add typed support for /works/{id}/ratings.json
- add typed support for /works/{id}/bookshelves.json
- add DocC comments to the new public API and strict Swift 6 concurrency-safe tests

## Verification
- swift test