### PR TITLE
feat: add first-class covers utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ let work = try await client.getWork(workKey: "OL45804W")
 // Returns an array of OpenLibraryEdition objects
 let editions = try await client.getWorkEditions(workKey: "OL45883W")
 
+// Build cover and author image URLs directly.
+let coverURL = OpenLibraryCovers.bookURL(for: .coverID(9238695), size: .large)
+let authorPhotoURL = OpenLibraryCovers.authorPhotoURL(for: .authorKey("OL23919A"), size: .medium)
+
 // With logging enabled (on Apple platforms)
 import OSLog
 let logger = Logger(subsystem: "com.yourapp", category: "openlibrary")

--- a/Sources/OpenLibrary/OpenLibraryCovers.swift
+++ b/Sources/OpenLibrary/OpenLibraryCovers.swift
@@ -1,0 +1,99 @@
+//
+//  OpenLibraryCovers.swift
+//
+//  Created by Natik Gadzhi on 4/4/26.
+//
+
+import Foundation
+
+/// Utilities for building Open Library image URLs.
+///
+/// This namespace does not perform network requests. It only builds stable,
+/// deterministic URLs from identifiers so callers can use the same logic across
+/// works, editions, authors, and external identifiers.
+public enum OpenLibraryCovers {
+    /// Supported image sizes for Open Library cover and author-photo assets.
+    public enum Size: String, CaseIterable, Sendable {
+        /// Small image variant (`-S`).
+        case small = "S"
+
+        /// Medium image variant (`-M`).
+        case medium = "M"
+
+        /// Large image variant (`-L`).
+        case large = "L"
+    }
+
+    /// Supported keys for book cover lookup.
+    public enum BookKey: Sendable {
+        /// An Open Library cover identifier.
+        case coverID(Int)
+
+        /// An Open Library edition key such as `OL7353617M`.
+        case editionKey(String)
+
+        /// A normalized or hyphenated ISBN value.
+        case isbn(String)
+
+        /// An OCLC identifier.
+        case oclc(String)
+
+        /// An LCCN identifier.
+        case lccn(String)
+    }
+
+    /// Supported keys for author photo lookup.
+    public enum AuthorKey: Sendable {
+        /// An Open Library author photo identifier.
+        case photoID(Int)
+
+        /// An Open Library author key such as `OL23919A`.
+        case authorKey(String)
+    }
+
+    /// Builds a cover image URL for a book-related identifier.
+    ///
+    /// - Parameters:
+    ///   - key: The identifier used by the Covers API.
+    ///   - size: The desired image size.
+    /// - Returns: A URL that can be fetched directly, or `nil` if URL creation fails.
+    public static func bookURL(for key: BookKey, size: Size = .large) -> URL? {
+        let path: String
+        switch key {
+        case .coverID(let id):
+            path = "/b/id/\(id)-\(size.rawValue).jpg"
+        case .editionKey(let key):
+            path = "/b/olid/\(key)-\(size.rawValue).jpg"
+        case .isbn(let isbn):
+            path = "/b/isbn/\(normalizedIdentifier(isbn))-\(size.rawValue).jpg"
+        case .oclc(let oclc):
+            path = "/b/oclc/\(normalizedIdentifier(oclc))-\(size.rawValue).jpg"
+        case .lccn(let lccn):
+            path = "/b/lccn/\(normalizedIdentifier(lccn))-\(size.rawValue).jpg"
+        }
+
+        return URL(string: "https://covers.openlibrary.org\(path)")
+    }
+
+    /// Builds an author photo URL.
+    ///
+    /// - Parameters:
+    ///   - key: The author identifier used by the Covers API.
+    ///   - size: The desired image size.
+    /// - Returns: A URL that can be fetched directly, or `nil` if URL creation fails.
+    public static func authorPhotoURL(for key: AuthorKey, size: Size = .large) -> URL? {
+        let path: String
+        switch key {
+        case .photoID(let id):
+            path = "/a/id/\(id)-\(size.rawValue).jpg"
+        case .authorKey(let key):
+            path = "/a/olid/\(key)-\(size.rawValue).jpg"
+        }
+
+        return URL(string: "https://covers.openlibrary.org\(path)")
+    }
+
+    private static func normalizedIdentifier(_ rawValue: String) -> String {
+        rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/OpenLibrary/OpenLibraryEdition.swift
+++ b/Sources/OpenLibrary/OpenLibraryEdition.swift
@@ -114,7 +114,9 @@ public struct OpenLibraryEdition: Codable, Identifiable, Sendable{
     ///
     public var coverImageURLs: [URL] {
         guard let coverImageIDs = coverImageIDs else { return [] }
-        return coverImageIDs.map { URL(string: "https://covers.openlibrary.org/b/id/\($0)-L.jpg")! }
+        return coverImageIDs.compactMap {
+            OpenLibraryCovers.bookURL(for: .coverID($0), size: .large)
+        }
     }
 
     /// First valid cover URL for this Edition

--- a/Sources/OpenLibrary/OpenLibraryWork.swift
+++ b/Sources/OpenLibrary/OpenLibraryWork.swift
@@ -81,7 +81,8 @@ public struct OpenLibraryWork: Codable, Identifiable, Hashable, Sendable {
 
     /// The first cover image URL if one exists.
     public var coverImageURL: URL? {
-        coverImageURLs.first
+        guard let firstCoverID = covers?.first else { return nil }
+        return OpenLibraryCovers.bookURL(for: .coverID(firstCoverID), size: .large)
     }
 
     /// The normalized author keys associated with this work.
@@ -126,7 +127,6 @@ public struct OpenLibraryWork: Codable, Identifiable, Hashable, Sendable {
         }
     }
 }
-
 extension OpenLibraryWork {
     /// A wrapped text field used by Open Library for some string values.
     public struct TextValue: Codable, Hashable, Sendable {

--- a/Tests/OpenLibraryAPITests/OpenLibraryCoversTests.swift
+++ b/Tests/OpenLibraryAPITests/OpenLibraryCoversTests.swift
@@ -1,0 +1,24 @@
+import Testing
+import OpenLibrary
+
+struct OpenLibraryCoversTests {
+    @Test func testBookCoverIDURLUsesExpectedFormat() {
+        let url = OpenLibraryCovers.bookURL(for: .coverID(9238695), size: .large)
+        #expect(url?.absoluteString == "https://covers.openlibrary.org/b/id/9238695-L.jpg")
+    }
+
+    @Test func testBookEditionKeyURLUsesExpectedFormat() {
+        let url = OpenLibraryCovers.bookURL(for: .editionKey("OL27847723M"), size: .medium)
+        #expect(url?.absoluteString == "https://covers.openlibrary.org/b/olid/OL27847723M-M.jpg")
+    }
+
+    @Test func testBookISBNURLPreservesIdentifier() {
+        let url = OpenLibraryCovers.bookURL(for: .isbn("9780300234176"), size: .small)
+        #expect(url?.absoluteString == "https://covers.openlibrary.org/b/isbn/9780300234176-S.jpg")
+    }
+
+    @Test func testAuthorPhotoURLUsesExpectedFormat() {
+        let url = OpenLibraryCovers.authorPhotoURL(for: .authorKey("OL23919A"), size: .large)
+        #expect(url?.absoluteString == "https://covers.openlibrary.org/a/olid/OL23919A-L.jpg")
+    }
+}


### PR DESCRIPTION
Closes #14

## Summary
- add a documented OpenLibraryCovers utility for book cover and author photo URLs
- route existing model cover URL helpers through the shared utility
- add tests for cover and author photo URL generation

## Verification
- swift test