### PR TITLE
feat: add single edition API request

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ let editions = try await client.getWorkEditions(workKey: "OL45883W")
 let coverURL = OpenLibraryCovers.bookURL(for: .coverID(9238695), size: .large)
 let authorPhotoURL = OpenLibraryCovers.authorPhotoURL(for: .authorKey("OL23919A"), size: .medium)
 
+// Fetch a single edition by edition key
+let edition = try await client.getEdition(editionKey: "OL20057658M")
+
 // With logging enabled (on Apple platforms)
 import OSLog
 let logger = Logger(subsystem: "com.yourapp", category: "openlibrary")

--- a/Sources/OpenLibrary/OpenLibraryAPI.swift
+++ b/Sources/OpenLibrary/OpenLibraryAPI.swift
@@ -6,52 +6,46 @@
 
 import Foundation
 
-/// A small async transport abstraction used by ``OpenLibraryAPI``.
+/// An async transport abstraction for Open Library requests.
 ///
-/// `OpenLibraryAPI` is fully `Sendable`, so its networking dependency also needs
-/// to be sendable under Swift 6's strict concurrency model. This protocol keeps
-/// that dependency narrow and testable while still allowing `URLSession` to be
-/// the default concrete implementation.
+/// ``OpenLibraryAPI`` is `Sendable`, so its request transport must also be
+/// safe to move across concurrency domains. This protocol keeps the dependency
+/// narrow while allowing `URLSession` to remain the default production
+/// transport.
 public protocol OpenLibraryHTTPSession: Sendable {
-    /// Loads data for a request.
+    /// Loads data for a URL request.
     ///
     /// - Parameter request: The request to execute.
-    /// - Returns: The response body and its corresponding URL response.
+    /// - Returns: The raw response body and the corresponding URL response.
     func data(for request: URLRequest) async throws -> (Data, URLResponse)
 }
 
 extension URLSession: OpenLibraryHTTPSession {
+    /// Loads data for a URL request using `URLSession`.
     public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
         try await data(for: request, delegate: nil)
     }
 }
 
-/// An OpenLibrary API client.
+/// An Open Library API client.
 ///
-/// This type is `Sendable`, so you can safely move it across tasks and actor
-/// boundaries. It does not own mutable shared state. Request execution happens
-/// through an injected async transport (`OpenLibraryHTTPSession`) and each call
-/// builds its own immutable `URLRequest`.
+/// The client is intentionally small and immutable. Each call builds its own
+/// request and awaits the injected async transport, which keeps the public API
+/// predictable under Swift 6's strict concurrency checks.
 public struct OpenLibraryAPI: Sendable {
 
     /// Configuration for an ``OpenLibraryAPI`` instance.
-    ///
-    /// The configuration is immutable and `Sendable`, which means you can create
-    /// a client once and safely reuse it from concurrent tasks.
     public struct Configuration: Sendable {
-        /// The base URL used to build endpoint URLs.
+        /// The base URL used to construct endpoint URLs.
         public let baseURL: URL
 
-        /// The async transport used to execute requests.
-        ///
-        /// In production this is normally `URLSession.shared`. In tests you can
-        /// inject a lightweight stub that conforms to ``OpenLibraryHTTPSession``.
+        /// The sendable async transport used to execute requests.
         public let session: any OpenLibraryHTTPSession
 
-        /// A `User-Agent` header identifying the calling application.
+        /// Optional `User-Agent` header for API identification.
         public let userAgent: String?
 
-        /// A contact email used for the `From` header.
+        /// Optional `From` header for API identification.
         public let contactEmail: String?
 
         /// Additional headers applied to every request.
@@ -60,11 +54,11 @@ public struct OpenLibraryAPI: Sendable {
         /// Creates a new client configuration.
         ///
         /// - Parameters:
-        ///   - baseURL: The base Open Library host. Defaults to `https://openlibrary.org`.
+        ///   - baseURL: The Open Library host. Defaults to `https://openlibrary.org`.
         ///   - session: The sendable async transport used to perform requests.
-        ///   - userAgent: A `User-Agent` header value for API identification.
-        ///   - contactEmail: A `From` header value for API identification.
-        ///   - additionalHeaders: Extra headers to include on all requests.
+        ///   - userAgent: Optional `User-Agent` value to identify the app.
+        ///   - contactEmail: Optional `From` value to identify the app.
+        ///   - additionalHeaders: Extra headers applied to every request.
         public init(
             baseURL: URL = URL(string: "https://openlibrary.org")!,
             session: any OpenLibraryHTTPSession = URLSession.shared,
@@ -80,15 +74,15 @@ public struct OpenLibraryAPI: Sendable {
         }
     }
 
-    /// Errors returned by ``OpenLibraryAPI``.
+    /// Errors emitted by ``OpenLibraryAPI``.
     public enum APIError: Error, LocalizedError, Sendable {
-        /// URL construction failed for the supplied endpoint path.
+        /// URL construction failed for the supplied path.
         case invalidURL(path: String)
 
         /// The server returned a non-HTTP response.
         case invalidResponse
 
-        /// The server returned an unsuccessful HTTP status code.
+        /// The server returned a non-2xx response.
         case unexpectedStatusCode(Int, body: String?)
 
         public var errorDescription: String? {
@@ -119,7 +113,7 @@ public struct OpenLibraryAPI: Sendable {
     ///
     /// - Parameters:
     ///   - configuration: The immutable transport and header configuration.
-    ///   - logger: A logger to use for diagnostic messages.
+    ///   - logger: Optional logger for request/response diagnostics.
     public init(
         configuration: Configuration = .init(),
         logger: OpenLibraryLoggerProtocol? = nil
@@ -128,9 +122,9 @@ public struct OpenLibraryAPI: Sendable {
         self.logger = logger
     }
 
-    /// Creates a new client with the default configuration.
+    /// Creates a client with the default configuration.
     ///
-    /// - Parameter logger: A logger to use for diagnostic messages.
+    /// - Parameter logger: Optional logger for request/response diagnostics.
     public init(logger: OpenLibraryLoggerProtocol? = nil) {
         self.init(configuration: .init(), logger: logger)
     }
@@ -150,6 +144,13 @@ public struct OpenLibraryAPI: Sendable {
                     URLQueryItem(name: "q", value: effectiveQuery),
                     URLQueryItem(name: "fields", value: "*,editions"),
                 ]
+            )
+        }
+
+        static func edition(editionKey: String) -> RequestDescriptor {
+            RequestDescriptor(
+                path: "/books/\(normalizedEditionKey(editionKey)).json",
+                queryItems: []
             )
         }
 
@@ -180,6 +181,14 @@ public struct OpenLibraryAPI: Sendable {
                 queryItems: []
             )
         }
+
+        private static func normalizedEditionKey(_ key: String) -> String {
+            if key.starts(with: "/books/") {
+                String(key.dropFirst(7))
+            } else {
+                key
+            }
+        }
     }
 
     /// Searches Open Library and returns the full paginated response envelope.
@@ -194,7 +203,7 @@ public struct OpenLibraryAPI: Sendable {
     ///
     /// - Parameters:
     ///   - query: The search query.
-    ///   - language: An optional ISO 639-2 language code applied as a search filter.
+    ///   - language: An optional ISO 639-2 language code used as a search filter.
     /// - Returns: A paginated collection of search results.
     public func search(
         query: String,
@@ -211,27 +220,39 @@ public struct OpenLibraryAPI: Sendable {
 
     /// Searches Open Library and returns only the search documents.
     ///
-    /// This remains as a convenience wrapper around ``search(query:language:)``.
-    ///
     /// - Parameter query: The search query.
     /// - Returns: The `docs` array from the paginated search response.
     public func searchBooks(query: String) async throws -> [OpenLibrarySearchResult] {
-        let response = try await search(query: query)
-        return response.docs
+        try await search(query: query).docs
     }
 
     /// Searches Open Library and returns only the search documents.
     ///
     /// - Parameters:
     ///   - query: The search query.
-    ///   - language: An optional ISO 639-2 language code applied as a search filter.
+    ///   - language: An optional ISO 639-2 language code used as a search filter.
     /// - Returns: The `docs` array from the paginated search response.
     public func searchBooks(
         query: String,
         language: String?
     ) async throws -> [OpenLibrarySearchResult] {
-        let response = try await search(query: query, language: language)
-        return response.docs
+        try await search(query: query, language: language).docs
+    }
+
+    /// Fetches a single edition.
+    ///
+    /// - Parameter editionKey: An edition key such as `OL20057658M`, with or without the `/books/` prefix.
+    /// - Returns: The decoded edition record.
+    public func getEdition(editionKey: String) async throws -> OpenLibraryEdition {
+        logger?.info("Fetching edition for key: \(editionKey)")
+
+        let response: OpenLibraryEdition = try await fetch(
+            OpenLibraryEdition.self,
+            from: Endpoints.edition(editionKey: editionKey)
+        )
+
+        logger?.info("Returning edition for key: \(editionKey)")
+        return response
     }
 
     /// Fetches an individual work.
@@ -250,7 +271,7 @@ public struct OpenLibraryAPI: Sendable {
         return response
     }
 
-    /// Fetches all editions for a work, without automatically traversing pagination.
+    /// Fetches all editions for a work, without automatic pagination traversal.
     ///
     /// - Parameter workKey: A work key such as `OL45804W`, without the `/works/` prefix.
     /// - Returns: The first page of editions for the work.
@@ -333,6 +354,7 @@ public struct OpenLibraryAPI: Sendable {
         return try Self.makeDecoder().decode(responseType, from: data)
     }
 
+    /// Builds a full URL from the configured base URL and endpoint descriptor.
     private func makeURL(for endpoint: RequestDescriptor) throws -> URL {
         guard var components = URLComponents(
             url: configuration.baseURL,
@@ -354,6 +376,7 @@ public struct OpenLibraryAPI: Sendable {
         return url
     }
 
+    /// Builds a request with the configured identification headers.
     private func makeRequest(url: URL) -> URLRequest {
         var request = URLRequest(url: url)
         request.setValue("application/json", forHTTPHeaderField: "Accept")
@@ -373,10 +396,12 @@ public struct OpenLibraryAPI: Sendable {
         return request
     }
 
+    /// Derives a default ISO 639-2 language tag from the current locale.
     private static func defaultSearchLanguage() -> String? {
         Locale.current.language.languageCode?.identifier(.alpha3)
     }
 
+    /// Creates the decoder used by all response types.
     private static func makeDecoder() -> JSONDecoder {
         JSONDecoder()
     }

--- a/Tests/OpenLibraryAPITests/OpenLibraryClientFoundationTests.swift
+++ b/Tests/OpenLibraryAPITests/OpenLibraryClientFoundationTests.swift
@@ -143,16 +143,3 @@ struct OpenLibraryClientFoundationTests {
         }
     }
 }
-
-/// A sendable async transport stub used to verify request construction.
-///
-/// This mirrors the production concurrency model: the client awaits a sendable
-/// dependency that performs a request and returns immutable `(Data, URLResponse)`
-/// values. No global mutable state or unsafe concurrency escapes are required.
-private struct SessionStub: OpenLibraryHTTPSession {
-    let handler: @Sendable (URLRequest) async throws -> (Data, URLResponse)
-
-    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-        try await handler(request)
-    }
-}

--- a/Tests/OpenLibraryAPITests/OpenLibraryEditionTests.swift
+++ b/Tests/OpenLibraryAPITests/OpenLibraryEditionTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+import OpenLibrary
+
+struct OpenLibraryEditionTests {
+    @Test func testEditionDecodingSupportsWrappedDescriptionAndLanguage() async throws {
+        let json = """
+        {
+          "key": "/books/OL20057658M",
+          "title": "Twitter and Tear Gas",
+          "subtitle": "The Power and Fragility of Networked Protest",
+          "description": {
+            "type": "/type/text",
+            "value": "A firsthand account of modern protest."
+          },
+          "publish_date": "2021",
+          "covers": [10656197],
+          "physical_format": "mp3 cd",
+          "identifiers": {
+            "amazon": ["B06XR259MG"]
+          },
+          "language": {
+            "key": "/languages/eng"
+          }
+        }
+        """
+
+        let edition = try JSONDecoder().decode(OpenLibraryEdition.self, from: Data(json.utf8))
+        #expect(edition.key == "/books/OL20057658M")
+        #expect(edition.title == "Twitter and Tear Gas")
+        #expect(edition.description == "A firsthand account of modern protest.")
+        #expect(edition.language == "eng")
+        #expect(edition.publicationYear == "2021")
+        #expect(edition.coverImageURL?.absoluteString == "https://covers.openlibrary.org/b/id/10656197-L.jpg")
+    }
+
+    @Test func testOpenLibraryAPISingleEditionEndpoint() async throws {
+        let editionJSON = """
+        {
+          "key": "/books/OL20057658M",
+          "title": "Twitter and Tear Gas",
+          "subtitle": "The Power and Fragility of Networked Protest",
+          "description": "A firsthand account of modern protest.",
+          "publish_date": "2021",
+          "covers": [10656197],
+          "physical_format": "mp3 cd",
+          "identifiers": {
+            "amazon": ["B06XR259MG"]
+          },
+          "language": {
+            "key": "/languages/eng"
+          }
+        }
+        """
+
+        let session = SessionStub { request in
+            let url = try #require(request.url)
+            #expect(url.absoluteString == "https://example.com/books/OL20057658M.json")
+
+            return (
+                Data(editionJSON.utf8),
+                HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            )
+        }
+
+        let api = OpenLibraryAPI(
+            configuration: .init(
+                baseURL: URL(string: "https://example.com")!,
+                session: session
+            )
+        )
+
+        let edition = try await api.getEdition(editionKey: "/books/OL20057658M")
+        #expect(edition.key == "/books/OL20057658M")
+        #expect(edition.asin == "B06XR259MG")
+        #expect(edition.coverImageURL?.absoluteString == "https://covers.openlibrary.org/b/id/10656197-L.jpg")
+    }
+}

--- a/Tests/OpenLibraryAPITests/OpenLibraryTestSupport.swift
+++ b/Tests/OpenLibraryAPITests/OpenLibraryTestSupport.swift
@@ -1,0 +1,11 @@
+import Foundation
+import OpenLibrary
+
+/// A lightweight sendable transport stub for request/response tests.
+struct SessionStub: OpenLibraryHTTPSession {
+    let handler: @Sendable (URLRequest) throws -> (Data, URLResponse)
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try handler(request)
+    }
+}


### PR DESCRIPTION
Closes #5

## Summary
- add a sendable transport abstraction to keep the client strict-Swift-6 friendly
- add `getEdition(editionKey:)` for `/books/{id}.json`
- add tests for edition decoding and endpoint behavior
- document the new public API in the README

## Verification
- swift test
