### PR TITLE
feat: add OpenLibrary SwiftPM CLI example

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,15 +15,29 @@ let package = Package(
         .library(
             name: "OpenLibrary",
             targets: ["OpenLibrary"]
+        ),
+        .executable(
+            name: "openlibrary",
+            targets: ["OpenLibraryCLI"]
         )
     ],
     targets: [
         .target(
             name: "OpenLibrary"
         ),
+        .executableTarget(
+            name: "OpenLibraryCLI",
+            dependencies: ["OpenLibrary"]
+        ),
         .testTarget(
             name: "OpenLibraryTests",
-            dependencies: ["OpenLibrary"]
+            dependencies: ["OpenLibrary"],
+            path: "Tests/OpenLibraryAPITests"
+        ),
+        .testTarget(
+            name: "OpenLibraryCLITests",
+            dependencies: ["OpenLibraryCLI"],
+            path: "Tests/OpenLibraryCLITests"
         ),
     ],
     swiftLanguageModes: [.v6]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ let logger = Logger(subsystem: "com.yourapp", category: "openlibrary")
 let clientWithLogging = OpenLibraryAPI(logger: logger)
 ```
 
+## CLI Example
+
+The package also includes a small executable example target for quick inspection
+from the terminal:
+
+```bash
+swift run openlibrary search "Pattern Recognition" --limit 3
+swift run openlibrary editions OL45883W --limit 5
+```
+
 ## Logging
 
 The library supports logging through a simple protocol `OpenLibraryLoggerProtocol`. On Apple platforms, `OSLog.Logger` is supported out of the box. For other platforms, you can implement the protocol with your preferred logging solution.

--- a/Sources/OpenLibraryCLI/CommandParser.swift
+++ b/Sources/OpenLibraryCLI/CommandParser.swift
@@ -1,0 +1,153 @@
+//
+//  CommandParser.swift
+//
+//  Created by Codex on 2026-04-04.
+//
+
+import Foundation
+
+/// A parsed CLI command.
+///
+/// The CLI keeps its argument model intentionally small so it remains easy to
+/// reason about without pulling in an argument parsing dependency.
+enum CLICommand: Equatable {
+    case help
+    case search(query: String, language: String?, limit: Int)
+    case editions(workKey: String, limit: Int)
+}
+
+/// Errors that can be emitted by the CLI parser.
+///
+/// These are user-facing parsing errors, not transport errors. They are mapped
+/// to exit codes by the main entry point.
+enum CLIError: Error, CustomStringConvertible, Equatable {
+    case unknownCommand(String)
+    case missingValue(String)
+    case invalidLimit(String)
+    case missingSearchQuery
+    case missingWorkKey
+
+    var description: String {
+        switch self {
+        case .unknownCommand(let command):
+            "Unknown command: \(command)"
+        case .missingValue(let option):
+            "Missing value for \(option)"
+        case .invalidLimit(let value):
+            "Invalid limit value: \(value)"
+        case .missingSearchQuery:
+            "Search requires a query string."
+        case .missingWorkKey:
+            "Editions requires a work key."
+        }
+    }
+
+    var exitCode: Int32 {
+        64
+    }
+}
+
+/// Parses command-line arguments into a CLI command.
+///
+/// The parser is intentionally simple: command names come first, followed by
+/// free-form positional tokens and a small set of `--flag value` options.
+struct CLIParser {
+    /// Parses the argument vector excluding the executable name.
+    func parse(_ arguments: [String]) throws -> CLICommand {
+        guard let command = arguments.first else {
+            return .help
+        }
+
+        switch command {
+        case "-h", "--help", "help":
+            return .help
+        case "search":
+            return try parseSearch(Array(arguments.dropFirst()))
+        case "editions":
+            return try parseEditions(Array(arguments.dropFirst()))
+        default:
+            throw CLIError.unknownCommand(command)
+        }
+    }
+
+    private func parseSearch(_ arguments: [String]) throws -> CLICommand {
+        var queryParts: [String] = []
+        var language: String?
+        var limit = 5
+
+        var iterator = arguments.makeIterator()
+        while let token = iterator.next() {
+            switch token {
+            case "--language", "-l":
+                guard let value = iterator.next() else {
+                    throw CLIError.missingValue(token)
+                }
+                language = value
+            case "--limit":
+                guard let value = iterator.next() else {
+                    throw CLIError.missingValue(token)
+                }
+                guard let parsedLimit = Int(value), parsedLimit > 0 else {
+                    throw CLIError.invalidLimit(value)
+                }
+                limit = parsedLimit
+            case "-h", "--help":
+                return .help
+            default:
+                queryParts.append(token)
+            }
+        }
+
+        let query = queryParts.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else {
+            throw CLIError.missingSearchQuery
+        }
+
+        return .search(query: query, language: language, limit: limit)
+    }
+
+    private func parseEditions(_ arguments: [String]) throws -> CLICommand {
+        var positional: [String] = []
+        var limit = 5
+
+        var iterator = arguments.makeIterator()
+        while let token = iterator.next() {
+            switch token {
+            case "--limit":
+                guard let value = iterator.next() else {
+                    throw CLIError.missingValue(token)
+                }
+                guard let parsedLimit = Int(value), parsedLimit > 0 else {
+                    throw CLIError.invalidLimit(value)
+                }
+                limit = parsedLimit
+            case "-h", "--help":
+                return .help
+            default:
+                positional.append(token)
+            }
+        }
+
+        guard let workKey = positional.first, !workKey.isEmpty else {
+            throw CLIError.missingWorkKey
+        }
+
+        return .editions(workKey: workKey, limit: limit)
+    }
+}
+
+/// Human-readable help text for the CLI example.
+enum CLIHelp {
+    static let usage = """
+    Open Library CLI
+
+    Usage:
+      openlibrary search <query> [--language <iso639-2>] [--limit <n>]
+      openlibrary editions <work-key> [--limit <n>]
+
+    Examples:
+      openlibrary search "Pattern Recognition"
+      openlibrary search "Foundation" --language eng --limit 3
+      openlibrary editions OL45883W --limit 5
+    """
+}

--- a/Sources/OpenLibraryCLI/OpenLibraryCLI.swift
+++ b/Sources/OpenLibraryCLI/OpenLibraryCLI.swift
@@ -1,0 +1,98 @@
+//
+//  OpenLibraryCLI.swift
+//
+//  Created by Codex on 2026-04-04.
+//
+
+import Foundation
+import OpenLibrary
+
+@main
+struct OpenLibraryCLI {
+    static func main() async {
+        do {
+            let parser = CLIParser()
+            let command = try parser.parse(Array(CommandLine.arguments.dropFirst()))
+            try await run(command)
+        } catch let error as CLIError {
+            Self.writeError("\(error.description)\n")
+            Self.writeError("\n\(CLIHelp.usage)\n")
+            exit(error.exitCode)
+        } catch {
+            Self.writeError("Unexpected error: \(error)\n")
+            exit(1)
+        }
+    }
+
+    private static func run(_ command: CLICommand) async throws {
+        let client = OpenLibraryAPI()
+
+        switch command {
+        case .help:
+            print(CLIHelp.usage)
+        case .search(let query, let language, let limit):
+            let books = try await client.searchBooks(query: query, language: language)
+            printSearchResults(books, query: query, limit: limit)
+        case .editions(let workKey, let limit):
+            let editions = try await client.getWorkEditions(workKey: workKey)
+            printEditions(editions, workKey: workKey, limit: limit)
+        }
+    }
+
+    private static func printSearchResults(
+        _ books: [OpenLibrarySearchResult],
+        query: String,
+        limit: Int
+    ) {
+        let visibleBooks = Array(books.prefix(limit))
+        print("Search results for \"\(query)\"")
+        print("Showing \(visibleBooks.count) of \(books.count) results")
+
+        for (index, book) in visibleBooks.enumerated() {
+            print("\n\(index + 1). \(book.title)")
+            if let author = book.author {
+                print("   Author: \(author)")
+            }
+            print("   Work key: \(book.key)")
+            if let editionCount = book.editionKeys?.count {
+                print("   Edition count: \(editionCount)")
+            }
+            if let coverImageURL = book.coverImageURL {
+                print("   Cover: \(coverImageURL.absoluteString)")
+            }
+        }
+    }
+
+    private static func printEditions(
+        _ editions: [OpenLibraryEdition],
+        workKey: String,
+        limit: Int
+    ) {
+        let visibleEditions = Array(editions.prefix(limit))
+        print("Editions for work \(workKey)")
+        print("Showing \(visibleEditions.count) of \(editions.count) results")
+
+        for (index, edition) in visibleEditions.enumerated() {
+            print("\n\(index + 1). \(edition.title)")
+            if let subtitle = edition.subtitle {
+                print("   Subtitle: \(subtitle)")
+            }
+            print("   Edition key: \(edition.key)")
+            if let publishDate = edition.publishDate {
+                print("   Publish date: \(publishDate)")
+            }
+            if let format = edition.format?.rawValue {
+                print("   Format: \(format)")
+            }
+            if let coverImageURL = edition.coverImageURL {
+                print("   Cover: \(coverImageURL.absoluteString)")
+            }
+        }
+    }
+
+    private static func writeError(_ message: String) {
+        if let data = message.data(using: .utf8) {
+            FileHandle.standardError.write(data)
+        }
+    }
+}

--- a/Tests/OpenLibraryCLITests/OpenLibraryCLIParserTests.swift
+++ b/Tests/OpenLibraryCLITests/OpenLibraryCLIParserTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import OpenLibraryCLI
+
+@Suite("OpenLibrary CLI parser")
+struct OpenLibraryCLIParserTests {
+    @Test func parsesSearchCommand() throws {
+        let command = try CLIParser().parse(["search", "Pattern", "Recognition", "--language", "eng", "--limit", "3"])
+
+        #expect(command == .search(query: "Pattern Recognition", language: "eng", limit: 3))
+    }
+
+    @Test func parsesEditionsCommand() throws {
+        let command = try CLIParser().parse(["editions", "OL45883W", "--limit", "2"])
+
+        #expect(command == .editions(workKey: "OL45883W", limit: 2))
+    }
+
+    @Test func rejectsMissingSearchQuery() throws {
+        #expect(throws: CLIError.self) {
+            try CLIParser().parse(["search", "--limit", "2"])
+        }
+    }
+
+    @Test func helpCommandIsRecognized() throws {
+        let command = try CLIParser().parse(["--help"])
+        #expect(command == .help)
+    }
+}


### PR DESCRIPTION
Closes #20

## Summary
- add an executable `openlibrary` target that can search books and inspect editions
- add a small, testable argument parser with no extra dependencies
- update the README with CLI usage examples

## Verification
- swift build
- swift test
- swift run openlibrary --help
