### PR TITLE
feat: add subjects API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ let authorPhotoURL = OpenLibraryCovers.authorPhotoURL(for: .authorKey("OL23919A"
 // Fetch a single edition by edition key
 let edition = try await client.getEdition(editionKey: "OL20057658M")
 
+// Fetch a subject page with expanded metadata.
+let subject = try await client.getSubject(
+    subjectSlug: "love",
+    options: .init(details: true, limit: 10)
+)
+
 // With logging enabled (on Apple platforms)
 import OSLog
 let logger = Logger(subsystem: "com.yourapp", category: "openlibrary")

--- a/Sources/OpenLibrary/OpenLibraryAPI.swift
+++ b/Sources/OpenLibrary/OpenLibraryAPI.swift
@@ -21,7 +21,7 @@ public protocol OpenLibraryHTTPSession: Sendable {
 }
 
 extension URLSession: OpenLibraryHTTPSession {
-    /// Loads data for a URL request using `URLSession`.
+    /// Bridges `URLSession` into the sendable transport abstraction.
     public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
         try await data(for: request, delegate: nil)
     }
@@ -101,6 +101,46 @@ public struct OpenLibraryAPI: Sendable {
         }
     }
 
+    /// Request options for the subjects endpoint.
+    public struct SubjectOptions: Sendable {
+        /// Include the expanded subject detail arrays.
+        public let details: Bool
+
+        /// Restrict results to works with ebooks when `true`.
+        public let ebooks: Bool?
+
+        /// Filter works published in a year range string, such as `1500-1600`.
+        public let publishedIn: String?
+
+        /// Limit the number of returned works.
+        public let limit: Int?
+
+        /// Offset into the subject work list.
+        public let offset: Int?
+
+        /// Creates a subject query value.
+        ///
+        /// - Parameters:
+        ///   - details: Include the expanded subject metadata arrays.
+        ///   - ebooks: Restrict results to works with ebooks when provided.
+        ///   - publishedIn: Filter by a published year range string.
+        ///   - limit: Maximum number of works to return.
+        ///   - offset: Starting offset into the work list.
+        public init(
+            details: Bool = false,
+            ebooks: Bool? = nil,
+            publishedIn: String? = nil,
+            limit: Int? = nil,
+            offset: Int? = nil
+        ) {
+            self.details = details
+            self.ebooks = ebooks
+            self.publishedIn = publishedIn
+            self.limit = limit
+            self.offset = offset
+        }
+    }
+
     struct RequestDescriptor: Sendable {
         let path: String
         let queryItems: [URLQueryItem]
@@ -129,7 +169,10 @@ public struct OpenLibraryAPI: Sendable {
         self.init(configuration: .init(), logger: logger)
     }
 
+    /// A list of supported Open Library API endpoints.
     enum Endpoints {
+        /// Search for books (works) providing a query and an optional language code.
+        /// If the language code is not provided, the language filter is omitted.
         static func search(query: String, language: String?) -> RequestDescriptor {
             let effectiveQuery: String
             if let language, !language.isEmpty {
@@ -154,6 +197,7 @@ public struct OpenLibraryAPI: Sendable {
             )
         }
 
+        /// Fetches a single work by work key.
         static func work(workKey: String) -> RequestDescriptor {
             RequestDescriptor(
                 path: "/works/\(workKey).json",
@@ -161,6 +205,7 @@ public struct OpenLibraryAPI: Sendable {
             )
         }
 
+        /// Fetches the list of editions for a work.
         static func editions(workKey: String) -> RequestDescriptor {
             RequestDescriptor(
                 path: "/works/\(workKey)/editions.json",
@@ -168,6 +213,37 @@ public struct OpenLibraryAPI: Sendable {
             )
         }
 
+        /// Fetches a subject page with optional query parameters.
+        static func subject(subjectSlug: String, options: SubjectOptions) -> RequestDescriptor {
+            var queryItems: [URLQueryItem] = []
+
+            if options.details {
+                queryItems.append(URLQueryItem(name: "details", value: "true"))
+            }
+
+            if let ebooks = options.ebooks {
+                queryItems.append(URLQueryItem(name: "ebooks", value: ebooks ? "true" : "false"))
+            }
+
+            if let publishedIn = options.publishedIn {
+                queryItems.append(URLQueryItem(name: "published_in", value: publishedIn))
+            }
+
+            if let limit = options.limit {
+                queryItems.append(URLQueryItem(name: "limit", value: String(limit)))
+            }
+
+            if let offset = options.offset {
+                queryItems.append(URLQueryItem(name: "offset", value: String(offset)))
+            }
+
+            return RequestDescriptor(
+                path: "/subjects/\(subjectSlug).json",
+                queryItems: queryItems
+            )
+        }
+
+        /// Fetches the rating summary for a work.
         static func ratings(workKey: String) -> RequestDescriptor {
             RequestDescriptor(
                 path: "/works/\(workKey)/ratings.json",
@@ -175,6 +251,7 @@ public struct OpenLibraryAPI: Sendable {
             )
         }
 
+        /// Fetches the public bookshelf counts for a work.
         static func bookshelves(workKey: String) -> RequestDescriptor {
             RequestDescriptor(
                 path: "/works/\(workKey)/bookshelves.json",
@@ -274,7 +351,7 @@ public struct OpenLibraryAPI: Sendable {
     /// Fetches all editions for a work, without automatic pagination traversal.
     ///
     /// - Parameter workKey: A work key such as `OL45804W`, without the `/works/` prefix.
-    /// - Returns: The first page of editions for the work.
+    /// - Returns: The first page of edition records for the work.
     public func getWorkEditions(workKey: String) async throws -> [OpenLibraryEdition] {
         logger?.info("Fetching editions for work key: \(workKey)")
 
@@ -324,6 +401,27 @@ public struct OpenLibraryAPI: Sendable {
         )
 
         logger?.info("Returning bookshelves for work key: \(workKey)")
+        return response
+    }
+
+    /// Fetches a subject record and its works.
+    ///
+    /// - Parameters:
+    ///   - subjectSlug: The subject slug without the `/subjects/` prefix.
+    ///   - options: Optional query parameters for details, ebooks, and pagination.
+    /// - Returns: A decoded subject record.
+    public func getSubject(
+        subjectSlug: String,
+        options: SubjectOptions = .init()
+    ) async throws -> OpenLibrarySubject {
+        logger?.info("Fetching subject for slug: \(subjectSlug)")
+
+        let response: OpenLibrarySubject = try await fetch(
+            OpenLibrarySubject.self,
+            from: Endpoints.subject(subjectSlug: subjectSlug, options: options)
+        )
+
+        logger?.info("Returning subject \(response.name) with \(response.works.count) works")
         return response
     }
 

--- a/Sources/OpenLibrary/OpenLibraryAPIMocks.swift
+++ b/Sources/OpenLibrary/OpenLibraryAPIMocks.swift
@@ -651,4 +651,77 @@ public enum OpenLibraryAPIMocks: Sendable {
     "offset": null
 }
 """
+
+    /// https://openlibrary.org/subjects/love.json?details=true
+    ///
+    public static let loveSubject = """
+    {
+      "key": "/subjects/love",
+      "name": "Love",
+      "subject_type": "subject",
+      "work_count": 4918,
+      "ebook_count": 497,
+      "works": [
+        {
+          "key": "/works/OL66534W",
+          "title": "Pride and prejudice",
+          "edition_count": 752,
+          "authors": [
+            {
+              "name": "Jane Austen",
+              "key": "/authors/OL21594A"
+            }
+          ],
+          "has_fulltext": true,
+          "ia": "mansfieldparknov03aust",
+          "cover_id": 1234567
+        }
+      ],
+      "authors": [
+        {
+          "count": 28,
+          "name": "Plato",
+          "key": "/authors/OL12823A"
+        }
+      ],
+      "publishers": [
+        {
+          "count": 54,
+          "name": "Sine nomine"
+        }
+      ],
+      "subjects": [
+        {
+          "count": 914,
+          "name": "Religious aspects of Love",
+          "key": "/subjects/religious_aspects_of_love"
+        }
+      ],
+      "people": [
+        {
+          "count": 44,
+          "name": "Jesus Christ",
+          "key": "/subjects/person:jesus_christ"
+        }
+      ],
+      "places": [
+        {
+          "count": 80,
+          "name": "United States",
+          "key": "/subjects/place:united_states"
+        }
+      ],
+      "times": [
+        {
+          "count": 54,
+          "name": "20th century",
+          "key": "/subjects/time:20th_century"
+        }
+      ],
+      "publishing_history": [
+        [1492, 2],
+        [2010, 56]
+      ]
+    }
+    """
 }

--- a/Sources/OpenLibrary/OpenLibrarySubject.swift
+++ b/Sources/OpenLibrary/OpenLibrarySubject.swift
@@ -1,0 +1,250 @@
+//
+//  OpenLibrarySubject.swift
+//
+//  Created by Natik Gadzhi on 4/4/26.
+//
+
+import Foundation
+
+/// A decoded Open Library subject record from `/subjects/{slug}.json`.
+///
+/// Subjects are useful browse pages. They include a main work list plus summary
+/// metadata such as total work counts, optional ebook counts, and, when
+/// requested, expanded contributor breakdowns.
+public struct OpenLibrarySubject: Decodable, Identifiable, Hashable, Sendable {
+    enum CodingKeys: String, CodingKey {
+        case key
+        case name
+        case subjectType = "subject_type"
+        case workCount = "work_count"
+        case ebookCount = "ebook_count"
+        case works
+        case authors
+        case publishers
+        case subjects
+        case people
+        case places
+        case times
+        case publishingHistory = "publishing_history"
+    }
+
+    /// The normalized subject key without the `/subjects/` prefix.
+    public var id: String { key }
+
+    /// The normalized subject key.
+    public let key: String
+
+    /// The subject display name.
+    public let name: String
+
+    /// The subject type returned by Open Library.
+    public let subjectType: String
+
+    /// The total number of works attached to the subject.
+    public let workCount: Int
+
+    /// The number of ebook works attached to the subject, if present.
+    public let ebookCount: Int?
+
+    /// The works associated with this subject page.
+    public let works: [OpenLibrarySubjectWork]
+
+    /// Popular authors returned when `details=true`.
+    public let authors: [OpenLibrarySubjectFacet]?
+
+    /// Popular publishers returned when `details=true`.
+    public let publishers: [OpenLibrarySubjectFacet]?
+
+    /// Related subjects returned when `details=true`.
+    public let subjects: [OpenLibrarySubjectFacet]?
+
+    /// Related people returned when `details=true`.
+    public let people: [OpenLibrarySubjectFacet]?
+
+    /// Related places returned when `details=true`.
+    public let places: [OpenLibrarySubjectFacet]?
+
+    /// Related time periods returned when `details=true`.
+    public let times: [OpenLibrarySubjectFacet]?
+
+    /// Annual publishing counts returned when `details=true`.
+    public let publishingHistory: [OpenLibrarySubjectPublishingHistoryPoint]?
+
+    /// The first cover image URL associated with the subject's first work.
+    public var coverImageURL: URL? {
+        works.first?.coverImageURL
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        key = Self.normalizeSubjectKey(try container.decode(String.self, forKey: .key))
+        name = try container.decode(String.self, forKey: .name)
+        subjectType = try container.decode(String.self, forKey: .subjectType)
+        workCount = try container.decode(Int.self, forKey: .workCount)
+        ebookCount = try container.decodeIfPresent(Int.self, forKey: .ebookCount)
+        works = try container.decodeIfPresent([OpenLibrarySubjectWork].self, forKey: .works) ?? []
+        authors = try container.decodeIfPresent([OpenLibrarySubjectFacet].self, forKey: .authors)
+        publishers = try container.decodeIfPresent([OpenLibrarySubjectFacet].self, forKey: .publishers)
+        subjects = try container.decodeIfPresent([OpenLibrarySubjectFacet].self, forKey: .subjects)
+        people = try container.decodeIfPresent([OpenLibrarySubjectFacet].self, forKey: .people)
+        places = try container.decodeIfPresent([OpenLibrarySubjectFacet].self, forKey: .places)
+        times = try container.decodeIfPresent([OpenLibrarySubjectFacet].self, forKey: .times)
+        publishingHistory = try container.decodeIfPresent(
+            [OpenLibrarySubjectPublishingHistoryPoint].self,
+            forKey: .publishingHistory
+        )
+    }
+
+    private static func normalizeSubjectKey(_ rawKey: String) -> String {
+        if rawKey.starts(with: "/subjects/") {
+            String(rawKey.dropFirst(10))
+        } else {
+            rawKey
+        }
+    }
+}
+
+/// A popular subject contributor returned in the expanded `details=true` view.
+public struct OpenLibrarySubjectFacet: Decodable, Hashable, Sendable {
+    enum CodingKeys: String, CodingKey {
+        case count
+        case name
+        case key
+    }
+
+    /// The item count returned by Open Library.
+    public let count: Int
+
+    /// The item display name.
+    public let name: String
+
+    /// The optional normalized key for the item.
+    public let key: String?
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        count = try container.decode(Int.self, forKey: .count)
+        name = try container.decode(String.self, forKey: .name)
+
+        if let rawKey = try container.decodeIfPresent(String.self, forKey: .key) {
+            key = Self.normalizeKey(rawKey)
+        } else {
+            key = nil
+        }
+    }
+
+    private static func normalizeKey(_ rawKey: String) -> String {
+        if rawKey.starts(with: "/authors/") {
+            String(rawKey.dropFirst(9))
+        } else if rawKey.starts(with: "/subjects/") {
+            String(rawKey.dropFirst(10))
+        } else {
+            rawKey
+        }
+    }
+}
+
+/// A subject work entry returned by Open Library.
+public struct OpenLibrarySubjectWork: Decodable, Identifiable, Hashable, Sendable {
+    enum CodingKeys: String, CodingKey {
+        case key
+        case title
+        case editionCount = "edition_count"
+        case authors
+        case hasFullText = "has_fulltext"
+        case ia
+        case coverID = "cover_id"
+    }
+
+    /// The normalized work key without the `/works/` prefix.
+    public var id: String { key }
+
+    /// The normalized work key.
+    public let key: String
+
+    /// The work title.
+    public let title: String
+
+    /// The number of editions associated with the work.
+    public let editionCount: Int?
+
+    /// The authors attached to the work entry.
+    public let authors: [OpenLibrarySubjectWorkAuthor]
+
+    /// Whether full text is available for the work.
+    public let hasFullText: Bool?
+
+    /// The Internet Archive identifier when present.
+    public let ia: String?
+
+    /// The Open Library cover identifier when present.
+    public let coverID: Int?
+
+    /// A convenience cover image URL if the work exposes a cover ID.
+    public var coverImageURL: URL? {
+        guard let coverID else { return nil }
+        return URL(string: "https://covers.openlibrary.org/b/id/\(coverID)-L.jpg")
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        key = Self.normalizeWorkKey(try container.decode(String.self, forKey: .key))
+        title = try container.decode(String.self, forKey: .title)
+        editionCount = try container.decodeIfPresent(Int.self, forKey: .editionCount)
+        authors = try container.decodeIfPresent([OpenLibrarySubjectWorkAuthor].self, forKey: .authors) ?? []
+        hasFullText = try container.decodeIfPresent(Bool.self, forKey: .hasFullText)
+        ia = try container.decodeIfPresent(String.self, forKey: .ia)
+        coverID = try container.decodeIfPresent(Int.self, forKey: .coverID)
+    }
+
+    private static func normalizeWorkKey(_ rawKey: String) -> String {
+        if rawKey.starts(with: "/works/") {
+            String(rawKey.dropFirst(7))
+        } else {
+            rawKey
+        }
+    }
+}
+
+/// A subject work author entry.
+public struct OpenLibrarySubjectWorkAuthor: Decodable, Hashable, Sendable {
+    enum CodingKeys: String, CodingKey {
+        case name
+        case key
+    }
+
+    /// The author display name.
+    public let name: String
+
+    /// The normalized author key without the `/authors/` prefix.
+    public let key: String
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+
+        let rawKey = try container.decode(String.self, forKey: .key)
+        if rawKey.starts(with: "/authors/") {
+            key = String(rawKey.dropFirst(9))
+        } else {
+            key = rawKey
+        }
+    }
+}
+
+/// A year/count pair used by the expanded subject publishing history.
+public struct OpenLibrarySubjectPublishingHistoryPoint: Decodable, Hashable, Sendable {
+    /// The publication year.
+    public let year: Int
+
+    /// The number of works published in that year.
+    public let count: Int
+
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        year = try container.decode(Int.self)
+        count = try container.decode(Int.self)
+    }
+}

--- a/Tests/OpenLibraryAPITests/OpenLibrarySubjectTests.swift
+++ b/Tests/OpenLibraryAPITests/OpenLibrarySubjectTests.swift
@@ -23,7 +23,7 @@ struct OpenLibrarySubjectTests {
     }
 
     @Test func testOpenLibraryAPISubjectEndpoint() async throws {
-        let session = SessionStub { request in
+        let session = SubjectSessionStub { request in
             let url = try #require(request.url)
             let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
 
@@ -67,7 +67,7 @@ struct OpenLibrarySubjectTests {
 }
 
 /// A sendable async transport stub used to verify subject request construction.
-private struct SessionStub: OpenLibraryHTTPSession {
+private struct SubjectSessionStub: OpenLibraryHTTPSession {
     let handler: @Sendable (URLRequest) async throws -> (Data, URLResponse)
 
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {

--- a/Tests/OpenLibraryAPITests/OpenLibrarySubjectTests.swift
+++ b/Tests/OpenLibraryAPITests/OpenLibrarySubjectTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+import OpenLibrary
+
+struct OpenLibrarySubjectTests {
+    @Test func testSubjectDecoding() async throws {
+        let subject = try JSONDecoder().decode(
+            OpenLibrarySubject.self,
+            from: OpenLibraryAPIMocks.loveSubject.data(using: .utf8)!
+        )
+
+        #expect(subject.key == "love")
+        #expect(subject.name == "Love")
+        #expect(subject.subjectType == "subject")
+        #expect(subject.workCount == 4918)
+        #expect(subject.ebookCount == 497)
+        #expect(subject.works.count == 1)
+        #expect(subject.works.first?.key == "OL66534W")
+        #expect(subject.works.first?.authors.first?.key == "OL21594A")
+        #expect(subject.authors?.first?.key == "OL12823A")
+        #expect(subject.publishingHistory?.first?.year == 1492)
+        #expect(subject.publishingHistory?.first?.count == 2)
+    }
+
+    @Test func testOpenLibraryAPISubjectEndpoint() async throws {
+        let session = SessionStub { request in
+            let url = try #require(request.url)
+            let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+
+            #expect(components.scheme == "https")
+            #expect(components.host == "example.com")
+            #expect(components.path == "/subjects/love.json")
+            #expect(components.queryItems?.first(where: { $0.name == "details" })?.value == "true")
+            #expect(components.queryItems?.first(where: { $0.name == "ebooks" })?.value == "true")
+            #expect(components.queryItems?.first(where: { $0.name == "published_in" })?.value == "1500-1600")
+            #expect(components.queryItems?.first(where: { $0.name == "limit" })?.value == "10")
+            #expect(components.queryItems?.first(where: { $0.name == "offset" })?.value == "20")
+
+            return (
+                Data(OpenLibraryAPIMocks.loveSubject.utf8),
+                HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            )
+        }
+
+        let api = OpenLibraryAPI(
+            configuration: .init(
+                baseURL: URL(string: "https://example.com")!,
+                session: session
+            )
+        )
+
+        let subject = try await api.getSubject(
+            subjectSlug: "love",
+            options: .init(
+                details: true,
+                ebooks: true,
+                publishedIn: "1500-1600",
+                limit: 10,
+                offset: 20
+            )
+        )
+
+        #expect(subject.key == "love")
+        #expect(subject.works.count == 1)
+        #expect(subject.coverImageURL?.absoluteString == "https://covers.openlibrary.org/b/id/1234567-L.jpg")
+    }
+}
+
+/// A sendable async transport stub used to verify subject request construction.
+private struct SessionStub: OpenLibraryHTTPSession {
+    let handler: @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await handler(request)
+    }
+}


### PR DESCRIPTION
Closes #13

## Summary
- add a typed subjects API with query options for details, ebooks, published_in, limit, and offset
- add decoded subject, work, contributor, and publishing history models
- add fixtures and tests for decoding plus endpoint behavior
- document the new public API with DocC-style comments and keep the transport strict-Swift-6 friendly

## Verification
- swift test